### PR TITLE
feat(recipes): keep screen on

### DIFF
--- a/app/src/main/java/de/kitshn/android/Utils.kt
+++ b/app/src/main/java/de/kitshn/android/Utils.kt
@@ -1,21 +1,29 @@
 package de.kitshn.android
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
+import android.view.Window
+import android.view.WindowManager
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogWindowProvider
 import de.kitshn.android.api.tandoor.model.TandoorFood
 import de.kitshn.android.api.tandoor.model.TandoorKeyword
 import kotlinx.serialization.InternalSerializationApi
@@ -90,6 +98,33 @@ fun Double.formatAmount(): String {
 fun Context.launchCustomTabs(url: String) {
     CustomTabsIntent.Builder().build()
         .launchUrl(this, Uri.parse(url))
+}
+
+tailrec fun Context.getActivityWindow(): Window? =
+    when(this) {
+        is Activity -> window
+        is ContextWrapper -> baseContext.getActivityWindow()
+        else -> null
+    }
+
+@Composable
+fun getDialogWindow(): Window? = (LocalView.current.parent as? DialogWindowProvider)?.window
+
+@Composable
+fun getActivityWindow(): Window? = LocalView.current.context.getActivityWindow()
+
+@Composable
+fun KeepScreenOn() {
+    val context = LocalContext.current
+
+    DisposableEffect(Unit) {
+        val window = context.getActivityWindow()
+        window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        onDispose {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/de/kitshn/android/ui/dialog/AdaptiveFullscreenDialog.kt
+++ b/app/src/main/java/de/kitshn/android/ui/dialog/AdaptiveFullscreenDialog.kt
@@ -1,10 +1,6 @@
 package de.kitshn.android.ui.dialog
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import android.view.View
-import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
@@ -47,26 +43,13 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
 import androidx.window.core.layout.WindowHeightSizeClass
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import de.kitshn.android.getActivityWindow
+import de.kitshn.android.getDialogWindow
 import de.kitshn.android.ui.component.buttons.BackButton
 import de.kitshn.android.ui.component.buttons.BackButtonType
-
-// Window utils
-@Composable
-fun getDialogWindow(): Window? = (LocalView.current.parent as? DialogWindowProvider)?.window
-
-@Composable
-fun getActivityWindow(): Window? = LocalView.current.context.getActivityWindow()
-
-private tailrec fun Context.getActivityWindow(): Window? =
-    when(this) {
-        is Activity -> window
-        is ContextWrapper -> baseContext.getActivityWindow()
-        else -> null
-    }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/de/kitshn/android/ui/route/recipe/cook/RecipeCook.kt
+++ b/app/src/main/java/de/kitshn/android/ui/route/recipe/cook/RecipeCook.kt
@@ -1,9 +1,5 @@
 package de.kitshn.android.ui.route.recipe.cook
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
-import android.view.WindowManager
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -17,7 +13,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -27,8 +22,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
+import de.kitshn.android.KeepScreenOn
 import de.kitshn.android.api.tandoor.TandoorRequestState
 import de.kitshn.android.api.tandoor.TandoorRequestStateState
 import de.kitshn.android.api.tandoor.model.TandoorStep
@@ -87,6 +82,7 @@ fun RouteRecipeCook(
 
     // ensure that the screen stays on, during the cooking
     KeepScreenOn()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -151,25 +147,4 @@ fun RouteRecipeCook(
             }
         }
     }
-}
-
-@Composable
-fun KeepScreenOn() {
-    val context = LocalContext.current
-    DisposableEffect(Unit) {
-        val window = context.findActivity()?.window
-        window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        onDispose {
-            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-    }
-}
-
-fun Context.findActivity(): Activity? {
-    var context = this
-    while (context is ContextWrapper) {
-        if (context is Activity) return context
-        context = context.baseContext
-    }
-    return null
 }

--- a/app/src/main/java/de/kitshn/android/ui/route/recipe/cook/RecipeCook.kt
+++ b/app/src/main/java/de/kitshn/android/ui/route/recipe/cook/RecipeCook.kt
@@ -1,5 +1,9 @@
 package de.kitshn.android.ui.route.recipe.cook
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.WindowManager
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -13,6 +17,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -22,6 +27,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import de.kitshn.android.api.tandoor.TandoorRequestState
 import de.kitshn.android.api.tandoor.TandoorRequestStateState
@@ -79,6 +85,8 @@ fun RouteRecipeCook(
     val pagerState =
         foreverRememberPagerState(key = "RouteRecipeCook/pagerState/${recipe!!.id}") { sortedSteps.size + 1 }
 
+    // ensure that the screen stays on, during the cooking
+    KeepScreenOn()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -143,4 +151,25 @@ fun RouteRecipeCook(
             }
         }
     }
+}
+
+@Composable
+fun KeepScreenOn() {
+    val context = LocalContext.current
+    DisposableEffect(Unit) {
+        val window = context.findActivity()?.window
+        window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+}
+
+fun Context.findActivity(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
 }


### PR DESCRIPTION
Disables the screen timeout, whilst the recipe screen is open. The avoids cases, where the screen constantly goes locks, whilst the user prepares an ingredient.

Unfortunately I wasn't able to test the code, as the debug app only displays a blank screen.