### PR TITLE
feat(commonMain/onboarding): remove trailing `/` from instance URL

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/OnboardingSignIn.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/OnboardingSignIn.kt
@@ -258,7 +258,7 @@ fun RouteOnboardingSignIn(
 
                         value = instanceUrlValue,
                         onValueChange = { value ->
-                            instanceUrlValue = value
+                            instanceUrlValue = value.trimEnd('/')
                         }
                     )
 


### PR DESCRIPTION
If the user enters an instance URL with a trailing `/`, the API path would be appended with its own leading slash, leading to an invalid URL such as: `https://app.tandoor.dev//api`.

![Instance URL with trailing slash](https://github.com/user-attachments/assets/5e873367-cade-4222-bb0b-2ef494d0fc70)
