### PR TITLE
feat(commonMain/recipes): default servings when adding to meal plan from details view

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
@@ -414,7 +414,8 @@ fun ViewRecipeDetails(
                         onAddToMealPlan = {
                             mealPlanCreationDialogState.open(
                                 MealPlanCreationAndEditDefaultValues(
-                                    recipeId = recipeOverview.id
+                                    recipeId = recipeOverview.id,
+                                    servings = recipeOverview.servings
                                 )
                             )
                         },


### PR DESCRIPTION
If the user adds a recipe to the meal plan, it defaults to the amount of servings on the recipe page.

[Screen_recording_20250320_231228.webm](https://github.com/user-attachments/assets/b19524bb-a520-4fe5-9853-42bf71a2bf29)
