### PR TITLE
fix(Shopping): shopping screen loading fixes

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/shopping/Shopping.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/shopping/Shopping.kt
@@ -143,25 +143,19 @@ fun RouteMainSubrouteShopping(
         p.vm.settings.getIngredientsShowFractionalValues.collectAsState(initial = true)
 
     val client = p.vm.tandoorClient
-    var isInitialLoad by remember { mutableStateOf(true) }
 
     // update shopping list entries
     LaunchedEffect(client) {
-        if (client == null) return@LaunchedEffect
+        if(client == null) return@LaunchedEffect
 
-        if (isInitialLoad) {
+        while(true) {
             vm.update()
-            isInitialLoad = false
-        }
-
-        while (true) {
             delay(5000)
-            vm.update()
         }
     }
     var firstRun by remember { mutableStateOf(true) }
     LaunchedEffect(additionalShoppingSettingsChipRowState.updateState) {
-        if (firstRun) {
+        if(firstRun) {
             firstRun = false
             return@LaunchedEffect
         }
@@ -249,7 +243,7 @@ fun RouteMainSubrouteShopping(
             Modifier.padding(pv)
         ) {
             Column {
-                if (client != null) AdditionalShoppingSettingsChipRow(
+                if(client != null) AdditionalShoppingSettingsChipRow(
                     client = client,
                     state = additionalShoppingSettingsChipRowState,
                     cache = supermarketCache
@@ -258,9 +252,9 @@ fun RouteMainSubrouteShopping(
                 HorizontalDivider()
 
                 LoadingGradientWrapper(
-                    loadingState = if (vm.loaded) ErrorLoadingSuccessState.SUCCESS else ErrorLoadingSuccessState.LOADING
+                    loadingState = if(vm.loaded) ErrorLoadingSuccessState.SUCCESS else ErrorLoadingSuccessState.LOADING
                 ) {
-                    if (vm.items.isEmpty() && vm.loaded) {
+                    if(vm.items.isEmpty() && vm.loaded) {
                         FullSizeAlertPane(
                             imageVector = Icons.Rounded.RemoveShoppingCart,
                             contentDescription = stringResource(Res.string.shopping_list_empty),
@@ -283,7 +277,7 @@ fun RouteMainSubrouteShopping(
                                 )
                                 .nestedScroll(scrollBehavior.nestedScrollConnection)
                         ) {
-                            if (!vm.loaded) {
+                            if(!vm.loaded) {
                                 item { ShoppingListGroupHeaderListItemPlaceholder() }
                                 item { ShoppingListEntryListItemPlaceholder() }
                                 item { ShoppingListEntryListItemPlaceholder() }
@@ -300,7 +294,7 @@ fun RouteMainSubrouteShopping(
                                 item { ShoppingListEntryListItemPlaceholder() }
                             } else {
                                 items(vm.items.size, key = { vm.items[it].key }) {
-                                    when (val item = vm.items[it]) {
+                                    when(val item = vm.items[it]) {
                                         is GroupHeaderShoppingListItemModel -> {
                                             ShoppingListGroupHeaderListItem(
                                                 label = { item.label }
@@ -344,7 +338,7 @@ fun RouteMainSubrouteShopping(
                 contentAlignment = Alignment.Center
             ) {
                 AnimatedContainedLoadingIndicator(
-                    visible = (vm.shoppingListEntriesFetchRequest.state == TandoorRequestStateState.LOADING) && isInitialLoad
+                    visible = vm.shoppingListEntriesFetchRequest.state == TandoorRequestStateState.LOADING
                 )
             }
 
@@ -448,8 +442,8 @@ fun RouteMainSubrouteShopping(
             state = shoppingListEntryDetailsBottomSheetState,
             isOffline = p.vm.uiState.offlineState.isOffline,
             onCheck = { entries ->
-                if (p.vm.uiState.offlineState.isOffline) {
-                    if (entries.all { entry -> entry.checked }) {
+                if(p.vm.uiState.offlineState.isOffline) {
+                    if(entries.all { entry -> entry.checked }) {
                         vm.executeOfflineAction(entries, ShoppingListEntryOfflineActions.UNCHECK)
                     } else {
                         vm.executeOfflineAction(entries, ShoppingListEntryOfflineActions.CHECK)
@@ -461,7 +455,7 @@ fun RouteMainSubrouteShopping(
 
                 coroutineScope.launch {
                     actionRequestState.wrapRequest {
-                        if (entries.all { entry -> entry.checked }) {
+                        if(entries.all { entry -> entry.checked }) {
                             client.shopping.uncheck(entries)
                         } else {
                             client.shopping.check(entries)
@@ -475,7 +469,7 @@ fun RouteMainSubrouteShopping(
                 }
             },
             onDelete = { entries ->
-                if (p.vm.uiState.offlineState.isOffline) {
+                if(p.vm.uiState.offlineState.isOffline) {
                     vm.executeOfflineAction(entries, ShoppingListEntryOfflineActions.DELETE)
                     hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentTick)
                     return@ShoppingListEntryDetailsBottomSheet


### PR DESCRIPTION
- prevent scrolling the FAB toolbar if content is not yet loaded
- only show loading spinner on initial load, not every 5 seconds