### PR TITLE
Don't sort lower and upper case differently on shopping list view

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/model/route/ShoppingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/model/route/ShoppingViewModel.kt
@@ -367,7 +367,7 @@ class ShoppingViewModel(
         val foodIdMap = mutableMapOf<Int, TandoorFood>()
         entries
             .onEach { foodIdMap[it.food.id] = it.food }
-            .sortedBy { it.food.name }
+            .sortedBy { it.food.name.lowercase() }
             .groupBy { it.food.id }
             .forEach { entry ->
                 foodIdMap[entry.key]?.let { food ->


### PR DESCRIPTION
Tandoor and its recipes easily results in mixed casing of items on the shopping list, for example if a recipe calls for "milk" and not "Milk" its possible that all shopping list entries for milk will be either case. When displaying on a shopping list it seems unlikely anyone would want "milk" to be displayed after "Salad" while "Milk" would be before "Salad".