### PR TITLE
Add chrome custom tabs browser auth on android for external OAuth sup…

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -79,6 +79,25 @@
         </activity>
 
         <activity
+            android:name="de.kitshn.OAuthCallbackActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="kitshn"
+                    android:host="auth"
+                    android:pathPrefix="/callback" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:excludeFromRecents="true"
             android:name="de.kitshn.NewInstanceActivity"
             android:exported="true" />

--- a/composeApp/src/androidMain/kotlin/de/kitshn/App.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/App.android.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import de.kitshn.actions.handleIntent
+import de.kitshn.actions.handleOAuthCallbackIntent
 import de.kitshn.actions.preHandleIntent
 
 class AppActivity : ComponentActivity() {
@@ -35,7 +36,10 @@ class AppActivity : ComponentActivity() {
     }
 
     override fun onNewIntent(intent: Intent) {
-        vm?.handleIntent(intent)
+        // Try OAuth callback first (comes from OAuthCallbackActivity)
+        if(vm?.handleOAuthCallbackIntent(intent) != true) {
+            vm?.handleIntent(intent)
+        }
         super.onNewIntent(intent)
     }
 

--- a/composeApp/src/androidMain/kotlin/de/kitshn/OAuthCallbackActivity.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/OAuthCallbackActivity.kt
@@ -1,0 +1,30 @@
+package de.kitshn
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+
+/**
+ * Transparent Activity that receives OAuth callback redirects
+ * (kitshn://auth/callback?token=...) from Chrome Custom Tabs,
+ * forwards the data to the main AppActivity, and finishes itself.
+ */
+class OAuthCallbackActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val callbackUri = intent.data
+
+        val mainIntent = Intent(this, AppActivity::class.java).apply {
+            action = ACTION_OAUTH_CALLBACK
+            data = callbackUri
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        startActivity(mainIntent)
+        finish()
+    }
+
+    companion object {
+        const val ACTION_OAUTH_CALLBACK = "de.kitshn.OAUTH_CALLBACK"
+    }
+}

--- a/composeApp/src/androidMain/kotlin/de/kitshn/actions/IntentHandler.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/actions/IntentHandler.kt
@@ -2,6 +2,7 @@ package de.kitshn.actions
 
 import android.content.Intent
 import de.kitshn.KitshnViewModel
+import de.kitshn.OAuthCallbackActivity
 import de.kitshn.actions.handlers.handleAppLink
 import de.kitshn.actions.handlers.handleShortcut
 import de.kitshn.api.tandoor.TandoorCredentials
@@ -15,6 +16,8 @@ fun KitshnViewModel.preHandleIntent(
     intent: Intent
 ): Boolean {
     if(intent.action == Intent.ACTION_MAIN) return false
+    // OAuth callbacks should not abort onboarding — just store the token
+    if(handleOAuthCallbackIntent(intent)) return false
     return handleAppLink(credentials, intent)
 }
 
@@ -23,6 +26,8 @@ fun KitshnViewModel.preHandleIntent(
  */
 fun KitshnViewModel.handleIntent(intent: Intent) {
     if(intent.action == Intent.ACTION_MAIN) return
+    if(handleOAuthCallbackIntent(intent)) return
+
     val text = (intent.getStringExtra(Intent.EXTRA_TEXT) ?: "")
 
     if(handleShortcut(intent)) return
@@ -35,4 +40,21 @@ fun KitshnViewModel.handleIntent(intent: Intent) {
             uiState.importRecipeUrl.set(url)
         }
     }
+}
+
+/**
+ * Handles OAuth callback intents from OAuthCallbackActivity.
+ * Callback URL format: kitshn://auth/callback?token={api_token}
+ */
+fun KitshnViewModel.handleOAuthCallbackIntent(intent: Intent): Boolean {
+    if(intent.action != OAuthCallbackActivity.ACTION_OAUTH_CALLBACK) return false
+    val uri = intent.data ?: return false
+
+    val token = uri.getQueryParameter("token")
+    if(token != null) {
+        handleOAuthCallback(token)
+        return true
+    }
+
+    return false
 }

--- a/composeApp/src/androidMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.android.kt
@@ -1,0 +1,32 @@
+package de.kitshn.ui.route.onboarding
+
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import co.touchlab.kermit.Logger
+
+@Composable
+actual fun LaunchBrowserAuthEffect(
+    launch: Boolean,
+    instanceUrl: String,
+    onLaunched: () -> Unit,
+    onFallbackToWebView: () -> Unit
+) {
+    val context = LocalContext.current
+
+    LaunchedEffect(launch) {
+        if (!launch) return@LaunchedEffect
+        try {
+            val customTabsIntent = CustomTabsIntent.Builder()
+                .setShowTitle(true)
+                .build()
+            customTabsIntent.launchUrl(context, Uri.parse(instanceUrl))
+            onLaunched()
+        } catch (e: Exception) {
+            Logger.e("LaunchBrowserAuth.android.kt", e)
+            onFallbackToWebView()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/de/kitshn/KitshnViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/KitshnViewModel.kt
@@ -23,6 +23,9 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
@@ -54,6 +57,18 @@ class KitshnViewModel(
     val settings = SettingsViewModel()
 
     val uiState = UiStateModel()
+
+    // OAuth callback state — set when an auth callback redirect is received
+    private val _oauthCallbackToken = MutableStateFlow<String?>(null)
+    val oauthCallbackToken: StateFlow<String?> = _oauthCallbackToken.asStateFlow()
+
+    fun handleOAuthCallback(token: String) {
+        _oauthCallbackToken.value = token
+    }
+
+    fun consumeOAuthCallback() {
+        _oauthCallbackToken.value = null
+    }
 
     lateinit var manageIosSubscriptionView: @Composable (p: RouteParameters) -> Unit
 

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.kt
@@ -1,0 +1,23 @@
+package de.kitshn.ui.route.onboarding
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Platform-specific browser auth launcher.
+ *
+ * On Android: launches a Chrome Custom Tab to [instanceUrl].
+ * On other platforms: calls [onFallbackToWebView] so the caller can
+ * navigate to the in-app WebView route instead.
+ *
+ * @param launch  set to true to trigger the launch
+ * @param instanceUrl  the Tandoor instance URL to authenticate against
+ * @param onLaunched  called after the Custom Tab has been launched (Android)
+ * @param onFallbackToWebView  called on platforms that don't support Custom Tabs
+ */
+@Composable
+expect fun LaunchBrowserAuthEffect(
+    launch: Boolean,
+    instanceUrl: String,
+    onLaunched: () -> Unit,
+    onFallbackToWebView: () -> Unit
+)

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/OnboardingSignIn.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/OnboardingSignIn.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -166,11 +167,65 @@ fun RouteOnboardingSignIn(
         }
     }
 
+    // Custom Tab browser auth state (Android only, others fall back to WebView)
+    var shouldLaunchBrowserAuth by remember { mutableStateOf(false) }
+
+    LaunchBrowserAuthEffect(
+        launch = shouldLaunchBrowserAuth,
+        instanceUrl = instanceUrlValue,
+        onLaunched = { shouldLaunchBrowserAuth = false },
+        onFallbackToWebView = {
+            shouldLaunchBrowserAuth = false
+            p.vm.navHostController?.navigate(
+                "onboarding/signIn/browser/${
+                    kotlin.io.encoding.Base64.encode(
+                        instanceUrlValue.encodeToByteArray()
+                    )
+                }"
+            )
+        }
+    )
+
+    val loginState = rememberTandoorRequestState()
+
+    // Observe OAuth callback token (arrives via Custom Tab redirect)
+    val oauthCallbackToken by p.vm.oauthCallbackToken.collectAsState()
+    LaunchedEffect(oauthCallbackToken) {
+        val token = oauthCallbackToken ?: return@LaunchedEffect
+        p.vm.consumeOAuthCallback()
+
+        loginState.wrapRequest {
+            val credentials = TandoorCredentials(
+                instanceUrl = instanceUrlValue,
+                token = TandoorCredentialsToken(
+                    token = token,
+                    scope = "oauth",
+                    expires = "undefined"
+                ),
+                customHeaders = customHeaders
+            )
+
+            val client = TandoorClient(credentials)
+            val user = client.user.get()
+            if(user != null) {
+                credentials.username = user.display_name
+                p.vm.uiState.userDisplayName = user.display_name
+                p.vm.signIn(client, credentials)
+                hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                return@wrapRequest
+            }
+
+            throw Error("OAUTH_TOKEN_INVALID")
+        }
+
+        if(loginState.state == TandoorRequestStateState.ERROR)
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.Reject)
+    }
+
     var usernameValue by rememberSaveable { mutableStateOf("") }
     var passwordValue by rememberSaveable { mutableStateOf("") }
     var tokenValue by rememberSaveable { mutableStateOf("") }
 
-    val loginState = rememberTandoorRequestState()
     LaunchedEffect(usernameValue, passwordValue, tokenValue) { loginState.reset() }
 
     fun done() {
@@ -508,13 +563,7 @@ fun RouteOnboardingSignIn(
 
                     OutlinedButton(
                         onClick = {
-                            p.vm.navHostController?.navigate(
-                                "onboarding/signIn/browser/${
-                                    kotlin.io.encoding.Base64.encode(
-                                        instanceUrlValue.encodeToByteArray()
-                                    )
-                                }"
-                            )
+                            shouldLaunchBrowserAuth = true
                         },
                         Modifier
                             .padding(16.dp)

--- a/composeApp/src/iosMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.ios.kt
+++ b/composeApp/src/iosMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.ios.kt
@@ -1,0 +1,17 @@
+package de.kitshn.ui.route.onboarding
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+@Composable
+actual fun LaunchBrowserAuthEffect(
+    launch: Boolean,
+    instanceUrl: String,
+    onLaunched: () -> Unit,
+    onFallbackToWebView: () -> Unit
+) {
+    LaunchedEffect(launch) {
+        if (!launch) return@LaunchedEffect
+        onFallbackToWebView()
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/kitshn/ui/route/onboarding/LaunchBrowserAuth.jvm.kt
@@ -1,0 +1,17 @@
+package de.kitshn.ui.route.onboarding
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+@Composable
+actual fun LaunchBrowserAuthEffect(
+    launch: Boolean,
+    instanceUrl: String,
+    onLaunched: () -> Unit,
+    onFallbackToWebView: () -> Unit
+) {
+    LaunchedEffect(launch) {
+        if (!launch) return@LaunchedEffect
+        onFallbackToWebView()
+    }
+}


### PR DESCRIPTION
adds chrome custom tabs browser auth in Android app so that users can use external oauth to authenticate to Tandoor instances with Authentik, Keycloak, Authelia, etc.