### PR TITLE
feat: sort meal types according to order

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/MealTypeSearchField.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/MealTypeSearchField.kt
@@ -73,8 +73,9 @@ fun BaseMealTypeSearchField(
     LaunchedEffect(Unit) {
         try {
             client.mealType.fetch().let { mealTypes ->
+                val sorted = mealTypes.sortedWith(compareBy({ it.order }, { it.time }))
                 mealTypeList.clear()
-                mealTypeList.addAll(mealTypes.sortedBy { it.order })
+                mealTypeList.addAll(sorted)
             }
         } catch(e: TandoorRequestsError) {
             Logger.e("MealTypeSearchField.kt", e)

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/MealTypeSearchField.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/MealTypeSearchField.kt
@@ -72,9 +72,9 @@ fun BaseMealTypeSearchField(
     val mealTypeList = remember { mutableStateListOf<TandoorMealType>() }
     LaunchedEffect(Unit) {
         try {
-            client.mealType.fetch().let {
+            client.mealType.fetch().let { mealTypes ->
                 mealTypeList.clear()
-                mealTypeList.addAll(it)
+                mealTypeList.addAll(mealTypes.sortedBy { it.order })
             }
         } catch(e: TandoorRequestsError) {
             Logger.e("MealTypeSearchField.kt", e)


### PR DESCRIPTION
A very small tweak again for the meal-type search field.
 
I would expect the meal types to be sorted according to the backend order field of the meals (in my own instance though everything has the same order).

?> Would it be better to also sort them by time, after sorting them by order?