### PR TITLE
Use semantic versioning for compatibility computation

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/settings/SettingsListItem.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/settings/SettingsListItem.kt
@@ -2,7 +2,6 @@ package de.kitshn.ui.component.settings
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -13,11 +12,11 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
@@ -53,6 +52,18 @@ fun SettingsListItem(
         } else {
             MaterialTheme.colorScheme.surfaceContainer
         }
+
+    val supportingColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor)
+
+    val colors = ListItemDefaults.colors(
+        containerColor = finalContainerColor,
+        leadingIconColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor),
+        headlineColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor),
+        supportingColor = when(supportingColor.isSpecified) {
+            true -> supportingColor.copy(alpha = 0.8f)
+            else -> supportingColor
+        }
+    )
 
     ListItem(
         modifier = modifier
@@ -109,13 +120,7 @@ fun SettingsListItem(
             )
             .alpha(if(enabled) 1f else 0.5f)
             .clickable { if(enabled) onClick() },
-        colors = ListItemDefaults.colors(
-            containerColor = finalContainerColor,
-            leadingIconColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor),
-            headlineColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor),
-            supportingColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor)
-                .copy(alpha = 0.8f)
-        ),
+        colors = colors,
         overlineContent = overlineContent,
         headlineContent = label,
         supportingContent = description,

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/settings/SettingsListItem.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/settings/SettingsListItem.kt
@@ -2,6 +2,7 @@ package de.kitshn.ui.component.settings
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,6 +13,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -40,15 +42,17 @@ fun SettingsListItem(
     trailingContent: @Composable () -> Unit = {},
     alternativeColors: Boolean = false,
     selected: Boolean = false,
+    containerColor: Color? = null,
     onClick: () -> Unit = {}
 ) {
-    val containerColor = if(selected) {
-        MaterialTheme.colorScheme.primaryContainer
-    } else if(alternativeColors) {
-        MaterialTheme.colorScheme.surfaceContainerLow
-    } else {
-        MaterialTheme.colorScheme.surfaceContainer
-    }
+    val finalContainerColor = containerColor
+        ?: if(selected) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else if(alternativeColors) {
+            MaterialTheme.colorScheme.surfaceContainerLow
+        } else {
+            MaterialTheme.colorScheme.surfaceContainer
+        }
 
     ListItem(
         modifier = modifier
@@ -106,10 +110,10 @@ fun SettingsListItem(
             .alpha(if(enabled) 1f else 0.5f)
             .clickable { if(enabled) onClick() },
         colors = ListItemDefaults.colors(
-            containerColor = containerColor,
-            leadingIconColor = MaterialTheme.colorScheme.contentColorFor(containerColor),
-            headlineColor = MaterialTheme.colorScheme.contentColorFor(containerColor),
-            supportingColor = MaterialTheme.colorScheme.contentColorFor(containerColor)
+            containerColor = finalContainerColor,
+            leadingIconColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor),
+            headlineColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor),
+            supportingColor = MaterialTheme.colorScheme.contentColorFor(finalContainerColor)
                 .copy(alpha = 0.8f)
         ),
         overlineContent = overlineContent,

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAbout.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAbout.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
+import com.mikepenz.aboutlibraries.ui.compose.produceLibraries
 import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
 import com.mikepenz.aboutlibraries.ui.compose.util.author
 import de.kitshn.launchWebsiteHandler
@@ -63,7 +64,7 @@ fun ViewSettingsAbout(
     val launchWebsite = launchWebsiteHandler()
     val uriHandler = LocalUriHandler.current
 
-    val libs by rememberLibraries {
+    val libs by produceLibraries {
         Res.readBytes("files/aboutlibraries.json").decodeToString()
     }
 

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsServer.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsServer.kt
@@ -1,7 +1,9 @@
 package de.kitshn.ui.view.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Logout
 import androidx.compose.material.icons.rounded.AccountCircle
@@ -34,6 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
 import de.kitshn.api.tandoor.TandoorRequestState
 import de.kitshn.closeAppHandler
 import de.kitshn.launchWebsiteHandler
@@ -42,6 +45,7 @@ import de.kitshn.ui.component.settings.SettingsListItem
 import de.kitshn.ui.component.settings.SettingsListItemPosition
 import de.kitshn.ui.dialog.version.TandoorServerVersionCompatibilityDialog
 import de.kitshn.ui.view.ViewParameters
+import de.kitshn.version.TandoorServerVersionCompatibility
 import kitshn.composeapp.generated.resources.Res
 import kitshn.composeapp.generated.resources.action_sign_out
 import kitshn.composeapp.generated.resources.action_sign_out_description
@@ -69,6 +73,9 @@ fun ViewSettingsServer(
 
     val launchWebsiteHandler = launchWebsiteHandler()
     val closeAppHandler = closeAppHandler()
+
+    val serverVersion = p.vm.tandoorClient?.container?.serverSettings?.version
+    val compatibilityState = TandoorServerVersionCompatibility.getCompatibilityStateOfVersion(serverVersion ?: "")
 
     var showVersionCompatibilityBottomSheet by remember { mutableStateOf(false) }
 
@@ -129,13 +136,22 @@ fun ViewSettingsServer(
                     label = { Text(stringResource(Res.string.common_version)) },
                     description = {
                         Text(
-                            p.vm.tandoorClient?.container?.serverSettings?.version
-                                ?: stringResource(Res.string.common_unknown)
+                            serverVersion ?: stringResource(Res.string.common_unknown)
                         )
                     },
                     icon = Icons.Rounded.Numbers,
-                    enabled = p.vm.tandoorClient?.container?.serverSettings?.version != null,
-                    contentDescription = stringResource(Res.string.common_version)
+                    trailingContent = {
+                        Icon(
+                            modifier = Modifier
+                                .padding(4.dp),
+                            imageVector = compatibilityState.icon,
+                            contentDescription = compatibilityState.label.toString(),
+                            tint = compatibilityState.iconTint()
+                        )
+                    },
+                    containerColor = compatibilityState.tint().copy(alpha = 0.1f),
+                    enabled = serverVersion != null,
+                    contentDescription = stringResource(Res.string.common_version),
                 ) {
                     coroutineScope.launch {
                         showVersionCompatibilityBottomSheet = true

--- a/composeApp/src/commonMain/kotlin/de/kitshn/version/TandoorServerVersionCompatibility.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/version/TandoorServerVersionCompatibility.kt
@@ -120,9 +120,9 @@ enum class TandoorServerVersionCompatibility(
         fun getCompatibilityStateOfVersion(version: String): TandoorServerVersionCompatibilityState {
             // versions precedence:
             // 1. Version found in version matrix -> use that
-            // 2. Go down bux-fix until 0 -> use that.
-            // 3. Go down minor-fix until 0 (also include bug fix version) -> MIXED_COMPATIBILITY
-            // Else Unknown
+            // 2. walk patch to 0 -> if found something use that
+            // 3. walk minor to 0 (including patches) -> at least MIXED_COMPATIBILITY or worse
+            // else Unknown
 
             val parts = version.split(".").map { it.toIntOrNull() ?: return TandoorServerVersionCompatibilityState.UNKNOWN }
             if (parts.size != 3) return TandoorServerVersionCompatibilityState.UNKNOWN

--- a/composeApp/src/commonMain/kotlin/de/kitshn/version/TandoorServerVersionCompatibility.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/version/TandoorServerVersionCompatibility.kt
@@ -27,6 +27,7 @@ enum class TandoorServerVersionCompatibilityState(
     val description: StringResource,
     val icon: ImageVector,
     val iconTint: @Composable () -> Color,
+    val tint: @Composable () -> Color,
     val hideCompatibleVersionsList: Boolean = false,
     val disableDismiss: Boolean = false
 ) {
@@ -35,32 +36,37 @@ enum class TandoorServerVersionCompatibilityState(
         description = Res.string.tandoor_compatibility_incompatible_description,
         icon = Icons.Rounded.Block,
         iconTint = { MaterialTheme.colorScheme.error },
+        tint = { MaterialTheme.colorScheme.error },
         disableDismiss = true
-    ),
-    MIXED_COMPATIBILITY(
-        label = Res.string.tandoor_compatibility_mixed_compatibility_label,
-        description = Res.string.tandoor_compatibility_mixed_compatibility_description,
-        icon = Icons.Rounded.WarningAmber,
-        iconTint = { Color.Yellow }
-    ),
-    FULL_COMPATIBILITY(
-        label = Res.string.tandoor_compatibility_full_compatibility_label,
-        description = Res.string.tandoor_compatibility_full_compatibility_description,
-        icon = Icons.Rounded.Check,
-        iconTint = { Color.Green },
-        hideCompatibleVersionsList = true
     ),
     UNKNOWN(
         label = Res.string.tandoor_compatibility_unknown_label,
         description = Res.string.tandoor_compatibility_unknown_description,
         icon = Icons.Rounded.QuestionMark,
-        iconTint = { Color.Gray }
+        iconTint = { Color.Gray },
+        tint = { Color.Gray }
+    ),
+    MIXED_COMPATIBILITY(
+        label = Res.string.tandoor_compatibility_mixed_compatibility_label,
+        description = Res.string.tandoor_compatibility_mixed_compatibility_description,
+        icon = Icons.Rounded.WarningAmber,
+        iconTint = { Color(0xFFBA8E23) }, // darker yellow
+        tint = { Color.Yellow }
+    ),
+    FULL_COMPATIBILITY(
+        label = Res.string.tandoor_compatibility_full_compatibility_label,
+        description = Res.string.tandoor_compatibility_full_compatibility_description,
+        icon = Icons.Rounded.Check,
+        iconTint = { Color(0xFF06402B) }, // darker green
+        tint = { Color.Green },
+        hideCompatibleVersionsList = true
     ),
     NOT_CHECKABLE(
         label = Res.string.tandoor_compatibility_not_checkable_label,
         description = Res.string.tandoor_compatibility_not_checkable_description,
         icon = Icons.Rounded.QuestionMark,
-        iconTint = { Color.Gray }
+        iconTint = { Color.Gray },
+        tint = { Color.Gray }
     )
 }
 
@@ -112,11 +118,40 @@ enum class TandoorServerVersionCompatibility(
         }
 
         fun getCompatibilityStateOfVersion(version: String): TandoorServerVersionCompatibilityState {
-            return try {
-                parseVersion(version).state
-            } catch(e: NullPointerException) {
-                TandoorServerVersionCompatibilityState.UNKNOWN
+            // versions precedence:
+            // 1. Version found in version matrix -> use that
+            // 2. Go down bux-fix until 0 -> use that.
+            // 3. Go down minor-fix until 0 (also include bug fix version) -> MIXED_COMPATIBILITY
+            // Else Unknown
+
+            val parts = version.split(".").map { it.toIntOrNull() ?: return TandoorServerVersionCompatibilityState.UNKNOWN }
+            if (parts.size != 3) return TandoorServerVersionCompatibilityState.UNKNOWN
+
+            val (major, minor, patch) = parts
+
+            try { return parseVersion(version).state } catch (_: NullPointerException) {}
+
+            // walk down bugfix and use that
+            for (p in (patch - 1) downTo 0){
+                try { return parseVersion("$major.$minor.$p").state } catch (_: NullPointerException) {}
             }
+
+            // walk down minor and if found anything return at least MIXED or the more severe state
+            for (m in (minor - 1) downTo 0) {
+                for (p in (patch - 1) downTo 0){
+                    try {
+                        val state = parseVersion("$major.$m.$p").state
+
+                        return if (state == TandoorServerVersionCompatibilityState.FULL_COMPATIBILITY) {
+                            TandoorServerVersionCompatibilityState.MIXED_COMPATIBILITY
+                        } else {
+                            state
+                        }
+                    } catch (_: NullPointerException) {}
+                }
+            }
+
+            return TandoorServerVersionCompatibilityState.UNKNOWN
         }
     }
 }


### PR DESCRIPTION
This adds a very very simple semantic versioning check for compatibilities to replace the strict compatibility matrix.
I think this is better and could alleviate some of your effort, since we trust that 2.6.6 does not change anything dramatic over 2.6.5 and users would not be annoyed on the dialog to show up
```  
// versions precedence:
// 1. Version found in version matrix -> use that
// 2. walk patch to 0 -> if found something use that
// 3. walk minor to 0 (including patches) -> at least MIXED_COMPATIBILITY or worse
// else Unknown
```
Then I also added that the version setting changes background color and adds a trailing icon for the given compatibility state. The colors had to be a bit darkened to make them visible enough.

---
Screenshots
Faked making 2.6.4 fully compatible.
<img width="1079" height="1418" alt="Screenshot_20260412-225233" src="https://github.com/user-attachments/assets/dbd35cf4-90d7-48f0-a89c-b764235f03d5" />
The current version matrix would result in 
<img width="1079" height="2280" alt="Screenshot_20260412-225201" src="https://github.com/user-attachments/assets/7e8ac18e-0134-4eb1-9d00-850b8c0f5825" />

