### PR TITLE
fix: reduce grid rerenders in home sections

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/home/HomePageSectionView.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/home/HomePageSectionView.kt
@@ -38,7 +38,7 @@ fun HomePageSectionView(
     onClickRecipe: (recipe: TandoorRecipeOverview) -> Unit
 ) {
     val lazyGridState =
-        rememberForeverLazyGridState(key = "RouteMainSubrouteHome/lazyGridState/${section.hashCode()}")
+        rememberForeverLazyGridState(key = "RouteMainSubrouteHome/lazyGridState/${section?.title ?: "loading"}")
 
     Column {
         Text(
@@ -59,12 +59,7 @@ fun HomePageSectionView(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             if(section != null) {
-                items(section.recipeIds.size, key = { index ->
-                    val recipeId = section.recipeIds[index]
-                    val recipe = client?.container?.recipeOverview?.get(recipeId)
-
-                    recipe?.let { "recipe-$it" } ?: "index-$index"
-                }) { index ->
+                items(section.recipeIds.size, key = {index -> section.recipeIds[index]}) { index ->
                     val recipeId = section.recipeIds[index]
                     val recipe = client?.container?.recipeOverview?.get(recipeId)
                         ?: return@items

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/home/HomeDynamicLayout.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/home/HomeDynamicLayout.kt
@@ -130,27 +130,22 @@ fun HomeDynamicLayout(
         }
     }
 
-    LaunchedEffect(homePageSectionList.toList()) {
-        if(homePageSectionList.size < 2) return@LaunchedEffect
-        pageLoadingState = ErrorLoadingSuccessState.SUCCESS
-    }
+    LaunchedEffect(homePage, homePage?.sectionsStateList?.size) {
+        if (homePage == null) return@LaunchedEffect
 
-    LaunchedEffect(homePage?.sectionsStateList?.toList()) {
-        if(homePage == null) return@LaunchedEffect
-
-        homePageSectionList.clear()
-        homePageSectionList.addAll(homePage!!.sections)
-
-        // keep page from loading indefinitely (prob. only happens when user has less than two recipes in space)
-        if(homePage?.sectionsStateList?.size == 0)
-            pageLoadingState = ErrorLoadingSuccessState.SUCCESS
-
-        // remove deleted recipes
-        homePageSectionList.forEach { section ->
-            section.recipeIds.removeIf {
-                !p.vm.tandoorClient!!.container.recipeOverview.contains(it)
-            }
+        val newSections = homePage!!.sections.onEach { section ->
+            section.recipeIds.removeIf { !p.vm.tandoorClient!!.container.recipeOverview.contains(it) }
         }
+
+        if (homePageSectionList != newSections) {
+            homePageSectionList.clear()
+            homePageSectionList.addAll(newSections)
+        }
+
+        if (homePage!!.sectionsStateList.isEmpty() || homePageSectionList.size >= 2) {
+            pageLoadingState = ErrorLoadingSuccessState.SUCCESS
+        }
+
     }
 
     val isScrollingUp = scrollState.isScrollingUp()
@@ -195,7 +190,7 @@ fun HomeDynamicLayout(
                         }
                     }
 
-                    if(homePageSectionList.size == 0 && pageLoadingState != ErrorLoadingSuccessState.SUCCESS) {
+                    if(homePageSectionList.isEmpty() && pageLoadingState != ErrorLoadingSuccessState.SUCCESS) {
                         repeat(5) {
                             HomePageSectionView(
                                 client = p.vm.tandoorClient,


### PR DESCRIPTION
This reduces the rerenders of the dynamic home grid and thus reduces the frequent flashing I see maybe even speed things up.

- For this the grid state was remembering with the section hash, which unfortunately changes to often. From my experimentation `section.title` is enough for a stable identifier.
- in items key the recipe index is enough we don't need more
- I don't know if toList is a good idea on Effect keys since it creates a new list. And we were setting `pageLoadingState = ErrorLoadingSuccessState.SUCCESS` multiple times potentially causing rerenders