### PR TITLE
fix: remove unnecessary imageLoaders

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/model/form/item/KitshnFormImageUploadItem.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/model/form/item/KitshnFormImageUploadItem.kt
@@ -30,10 +30,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
-import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import de.kitshn.ui.dialog.ChoosePhotoBottomSheet
 import de.kitshn.ui.modifier.loadingPlaceHolder
@@ -58,9 +56,6 @@ class KitshnFormImageUploadItem(
     override fun Render(
         modifier: Modifier
     ) {
-        val context = LocalPlatformContext.current
-        val imageLoader = remember { ImageLoader(context) }
-
         var imageLoadingState by remember {
             mutableStateOf<AsyncImagePainter.State>(
                 AsyncImagePainter.State.Loading(null)
@@ -92,7 +87,6 @@ class KitshnFormImageUploadItem(
                             },
                             contentDescription = label(),
                             contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .loadingPlaceHolder(imageLoadingState.translateState())
@@ -105,7 +99,6 @@ class KitshnFormImageUploadItem(
                             },
                             contentDescription = label(),
                             contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .loadingPlaceHolder(imageLoadingState.translateState())

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/recipe/RecipeSearchField.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/recipe/RecipeSearchField.kt
@@ -31,9 +31,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.TandoorClient
 import de.kitshn.api.tandoor.TandoorRequestState
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipeOverview
@@ -59,8 +57,6 @@ fun BaseRecipeSearchField(
         onValueChange: (value: String) -> Unit
     ) -> Unit
 ) {
-    val context = LocalPlatformContext.current
-
     var selectedRecipe by remember { mutableStateOf<TandoorRecipeOverview?>(null) }
     LaunchedEffect(selectedRecipe) { onValueChange(selectedRecipe?.id) }
 
@@ -106,7 +102,6 @@ fun BaseRecipeSearchField(
                         model = selectedRecipe?.loadThumbnail(),
                         contentDescription = stringResource(Res.string.common_title_image),
                         contentScale = ContentScale.Crop,
-                        imageLoader = ImageLoader(context),
                         modifier = Modifier
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCard.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCard.kt
@@ -12,15 +12,12 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipeOverview
 import de.kitshn.ui.theme.Typography
 import de.kitshn.ui.theme.playfairDisplay
@@ -37,9 +34,6 @@ fun HorizontalRecipeCard(
     onClick: (recipeOverview: TandoorRecipeOverview) -> Unit,
     onLongClick: (recipeOverview: TandoorRecipeOverview) -> Unit
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     Card(
         modifier = modifier,
         onClick = { onClick(recipeOverview) }
@@ -60,7 +54,6 @@ fun HorizontalRecipeCard(
                         model = recipeOverview.loadThumbnail(),
                         contentDescription = recipeOverview.name,
                         contentScale = ContentScale.Crop,
-                        imageLoader = imageLoader,
                         modifier = Modifier
                             .size(64.dp)
                             .clip(RoundedCornerShape(16.dp))

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCardLink.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCardLink.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -18,9 +17,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipeOverview
 import de.kitshn.ui.selectionMode.SelectionModeState
 import de.kitshn.ui.selectionMode.values.selectionModeListItemColors
@@ -35,9 +32,6 @@ fun HorizontalRecipeCardLink(
     defaultColors: ListItemColors = ListItemDefaults.colors(),
     onClick: (recipeOverview: TandoorRecipeOverview) -> Unit
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val hapticFeedback = LocalHapticFeedback.current
 
     val colors = ListItemDefaults.selectionModeListItemColors(
@@ -75,7 +69,6 @@ fun HorizontalRecipeCardLink(
                             model = recipeOverview.loadThumbnail(),
                             contentDescription = recipeOverview.name,
                             contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader,
                             modifier = Modifier
                                 .size(48.dp)
                                 .clip(RoundedCornerShape(8.dp))

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/RecipeCard.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/RecipeCard.kt
@@ -31,10 +31,8 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
-import coil3.compose.LocalPlatformContext
 import de.kitshn.KITSHN_KEYWORD_FLAG_PREFIX
 import de.kitshn.TestTagRepository
 import de.kitshn.api.tandoor.model.TandoorKeywordOverview
@@ -66,9 +64,6 @@ fun RecipeCard(
     onClickKeyword: (keyword: TandoorKeywordOverview) -> Unit,
     onClick: (recipeOverview: TandoorRecipeOverview) -> Unit,
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val hapticFeedback = LocalHapticFeedback.current
     val hazeState = remember { HazeState() }
 
@@ -124,7 +119,6 @@ fun RecipeCard(
                     },
                     contentDescription = recipeOverview?.name,
                     contentScale = ContentScale.Crop,
-                    imageLoader = imageLoader,
                     modifier = Modifier
                         .fillMaxWidth()
                         .run {

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/step/RecipeStepMultimediaBox.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/step/RecipeStepMultimediaBox.kt
@@ -31,10 +31,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.model.TandoorStep
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipe
 import de.kitshn.ui.dialog.AdaptiveFullscreenDialog
@@ -54,9 +52,6 @@ fun RecipeStepMultimediaBox(
     additionalContent: @Composable () -> Unit = { },
     placeholder: @Composable () -> Unit = { }
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val isVideo = (step.file?.name ?: "").contains("video")
 
     if(isVideo && !isVideoSupported()) {
@@ -98,7 +93,6 @@ fun RecipeStepMultimediaBox(
             },
             contentDescription = step.name,
             contentScale = ContentScale.Crop,
-            imageLoader = imageLoader,
             modifier = Modifier
                 .padding(contentPadding)
                 .fillMaxWidth()
@@ -159,9 +153,6 @@ private fun ImageDialog(
     onDismiss: () -> Unit,
     step: TandoorStep
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     var imageLoadingState by remember {
         mutableStateOf<AsyncImagePainter.State>(
             AsyncImagePainter.State.Loading(
@@ -196,7 +187,6 @@ private fun ImageDialog(
             },
             contentDescription = step.name,
             contentScale = ContentScale.Fit,
-            imageLoader = imageLoader,
             modifier = Modifier
                 .loadingPlaceHolder(
                     loadingState = imageLoadingState.translateState(),

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipebook/HorizontalRecipeBookCard.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipebook/HorizontalRecipeBookCard.kt
@@ -34,9 +34,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.TestTagRepository
 import de.kitshn.api.tandoor.model.TandoorRecipeBook
 import de.kitshn.api.tandoor.rememberTandoorRequestState
@@ -69,9 +67,6 @@ fun HorizontalRecipeBookCard(
 
     onClick: (recipeBook: TandoorRecipeBook) -> Unit = {}
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val hapticFeedback = LocalHapticFeedback.current
 
     val colors = CardDefaults.selectionModeCardColors(
@@ -168,7 +163,6 @@ fun HorizontalRecipeBookCard(
                                 model = recipeBook?.loadThumbnail(),
                                 contentDescription = recipeBook?.name,
                                 contentScale = ContentScale.Crop,
-                                imageLoader = imageLoader,
                                 modifier = Modifier
                                     .height(42.dp)
                                     .width(42.dp)
@@ -204,7 +198,7 @@ fun HorizontalRecipeBookCard(
                         text = if(isFavoritesBook) {
                             stringResource(Res.string.recipe_book_favorites_description)
                         } else {
-                            recipeBook?.description ?: ""
+                            recipeBook.description ?: ""
                         },
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/dialog/recipe/import/RecipeImportCommon.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/dialog/recipe/import/RecipeImportCommon.kt
@@ -37,9 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.TandoorRequestState
 import de.kitshn.api.tandoor.TandoorRequestStateState
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipe
@@ -143,9 +141,6 @@ fun LazyListScope.RecipeImportCommon(
         }
 
         item {
-            val context = LocalPlatformContext.current
-            val imageLoader = remember { ImageLoader(context) }
-
             var showChoosePhotoDialog by remember { mutableStateOf(false) }
 
             HorizontalMultiBrowseCarousel(
@@ -173,7 +168,6 @@ fun LazyListScope.RecipeImportCommon(
                                 model = data.uploadImage,
                                 contentDescription = "",
                                 contentScale = ContentScale.Crop,
-                                imageLoader = imageLoader
                             )
 
                             Box(
@@ -230,7 +224,6 @@ fun LazyListScope.RecipeImportCommon(
                             model = url,
                             contentDescription = url,
                             contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader
                         )
 
                         if(data.selectedImageUrl == url) Box(

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/recipe/cook/page/RecipeDone.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/recipe/cook/page/RecipeDone.kt
@@ -50,9 +50,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.TandoorRequestStateState
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipe
 import de.kitshn.api.tandoor.rememberTandoorRequestState
@@ -78,9 +76,6 @@ fun RouteRecipeCookPageDone(
     recipe: TandoorRecipe,
     servings: Int
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val coroutineScope = rememberCoroutineScope()
     val requestCookLogCreateState = rememberTandoorRequestState()
 
@@ -135,7 +130,6 @@ fun RouteRecipeCookPageDone(
                         model = recipe.loadThumbnail(),
                         contentDescription = recipe.name,
                         contentScale = ContentScale.Crop,
-                        imageLoader = imageLoader,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(180.dp)

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
@@ -92,9 +92,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import com.eygraber.uri.Uri
 import de.kitshn.KITSHN_KEYWORD_FLAG_PREFIX
 import de.kitshn.KITSHN_KEYWORD_FLAG__HIDE_INGREDIENT_ALLOCATION_ACTION_CHIP
@@ -215,9 +213,6 @@ fun ViewRecipeDetails(
 
     overrideServings: Double? = null
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val websiteHandler = launchWebsiteHandler()
     val shareContentHandler = shareContentHandler()
 
@@ -662,7 +657,6 @@ fun ViewRecipeDetails(
                     model = recipeOverview.loadThumbnail(),
                     contentDescription = recipeOverview.name,
                     contentScale = ContentScale.Crop,
-                    imageLoader = imageLoader,
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(16f / 9f)


### PR DESCRIPTION
I am not 100% sure about this or if there were some intention behind it, but I think the usual imageLoader creation on all composables i.e.
```kt
val context = LocalPlatformContext.current
val imageLoader = remember { ImageLoader(context) }
```
creates a new imageLoader everytime instead using the singleton which coil is designed surround.

- https://coil-kt.github.io/coil/api/coil-core/coil3/-image-loader.html

I am not sure about the context, it could be that is just using the singleton. 
But if not this is very counterproductive, since this is both an expensive operation and results in no image caching.

And in anycase we don't need it. The AsyncImage organizes it's imageLoader itself using the singleton as shown in their get started and makes for cleaner code.

- https://coil-kt.github.io/coil/getting_started/