### PR TITLE
feat: implemented setting to double-click shopping items to complete

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -345,6 +345,8 @@
     <string name="settings_section_behavior_ios_install_timer_shortcut_label">iOS-Timer-Kurzbefehl installieren</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_description">Verhindert, dass der Bildschirm beim Ansehen von Rezeptdetails in den Ruhezustand wechselt – genau wie im Kochmodus.</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_label">Bildschirm in Rezeptübersicht eingeschaltet lassen</string>
+    <string name="settings_section_behavior_shopping_item_double_click_check_label">Einkäufe per Doppelklick abhaken</string>
+    <string name="settings_section_behavior_shopping_item_double_click_check_description">Einkaufslisteneinträge durch schnelles Doppelklicken als erledigt markieren</string>
     <string name="settings_section_behavior_label">Verhalten</string>
     <string name="settings_section_behavior_properties_show_fractional_values_description">Eventuell einfacher zu lesen, allerdings weniger akkurat</string>
     <string name="settings_section_behavior_properties_show_fractional_values_label">Werte für Eigenschaften als Brüche anzeigen</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -419,5 +419,7 @@
     <string name="settings_section_behavior_ios_install_timer_shortcut_description">Nécessaire pour démarrer des minuteurs directement depuis l'application kitshn</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_description">Empêcher l'écran de se mettre en veille pendant l’affichage de la recette, tout comme dans le Mode cuisine</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_label">Gardez l’affichage de la recette actif</string>
+    <string name="settings_section_behavior_shopping_item_double_click_check_label">Cocher les articles par double-clic</string>
+    <string name="settings_section_behavior_shopping_item_double_click_check_description">Marquez rapidement vos articles comme terminés en double-cliquant dessus</string>
     <string name="common_shopping_list">Liste de courses</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -406,6 +406,8 @@
     <string name="settings_section_behavior_ios_install_timer_shortcut_label">Install iOS timer shortcut</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_description">Prevent the screen from sleeping while viewing recipe details, just like in Cooking Mode</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_label">Keep screen on in recipe overview</string>
+    <string name="settings_section_behavior_shopping_item_double_click_check_label">Double-click to check shopping items</string>
+    <string name="settings_section_behavior_shopping_item_double_click_check_description">Quickly mark shopping items as completed by double-clicking</string>
     <string name="settings_section_behavior_label">Behavior</string>
     <string name="settings_section_behavior_promote_tomorrows_meal_plan_description">Show the entries of tomorrow instead of today's entries</string>
     <string name="settings_section_behavior_promote_tomorrows_meal_plan_label">Promote tomorrow's meal plan instead</string>

--- a/composeApp/src/commonMain/kotlin/de/kitshn/Settings.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/Settings.kt
@@ -51,6 +51,9 @@ const val KEY_SETTINGS_BEHAVIOR_KEEP_SCREEN_ON_IN_RECIPE_DETAILS =
 const val KEY_SETTINGS_BEHAVIOR_HIDE_FUNDING_BANNER_UNTIL =
     "behavior_hide_funding_banner_until"
 
+const val KEY_SETTINGS_BEHAVIOR_SHOPPING_ITEM_DOUBLE_CLICK_CHECK =
+    "behavior_shopping_item_double_click_check"
+
 const val KEY_SETTINGS_SHOPPING_GROUP_BY = "shopping_group_by"
 const val KEY_SETTINGS_SHOPPING_SUPERMARKET = "shopping_supermarket"
 const val KEY_SETTINGS_SHOPPING_LISTS = "shopping_lists"
@@ -224,6 +227,12 @@ class SettingsViewModel : ViewModel() {
 
     fun setFundingBannerHideUntil(epochSeconds: Long) =
         obs.putLong(KEY_SETTINGS_BEHAVIOR_HIDE_FUNDING_BANNER_UNTIL, epochSeconds)
+
+    val getShoppingItemDoubleClickCheck: Flow<Boolean> =
+        obs.getBooleanFlow(KEY_SETTINGS_BEHAVIOR_SHOPPING_ITEM_DOUBLE_CLICK_CHECK, true)
+
+    fun setShoppingItemDoubleClickCheck(allow: Boolean) =
+        obs.putBoolean(KEY_SETTINGS_BEHAVIOR_SHOPPING_ITEM_DOUBLE_CLICK_CHECK, allow)
 
     // shopping
     fun setShoppingGroupBy(groupBy: String) =

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/shopping/ShoppingListEntryListItem.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/shopping/ShoppingListEntryListItem.kt
@@ -137,7 +137,8 @@ fun ShoppingListEntryListItem(
     enlarge: Boolean = false,
 
     onClick: (() -> Unit)? = null,
-    onClickExpand: (() -> Unit)? = null
+    onClickExpand: (() -> Unit)? = null,
+    onDoubleClick: (() -> Unit)? = null
 ) {
     val amountChips = remember { mutableStateListOf<Pair<String, Boolean>>() }
     val mealplans =
@@ -220,6 +221,9 @@ fun ShoppingListEntryListItem(
                         onLongClick = {
                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                             selectionState?.selectToggle(food.id)
+                        },
+                        onDoubleClick = {
+                            onDoubleClick?.invoke()
                         }
                     )
                 } else {

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/shopping/Shopping.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/shopping/Shopping.kt
@@ -48,6 +48,7 @@ import coil3.PlatformContext
 import coil3.compose.LocalPlatformContext
 import de.kitshn.TestTagRepository
 import de.kitshn.api.tandoor.TandoorRequestStateState
+import de.kitshn.api.tandoor.model.shopping.TandoorShoppingListEntry
 import de.kitshn.api.tandoor.rememberTandoorRequestState
 import de.kitshn.cache.ShoppingListCache
 import de.kitshn.cache.ShoppingListEntriesCache
@@ -171,6 +172,34 @@ fun RouteMainSubrouteShopping(
         }
 
         vm.renderItems()
+    }
+
+    val allowDoubleClickCheck by p.vm.settings.getShoppingItemDoubleClickCheck.collectAsState(true)
+    fun checkEntries(entries: List<TandoorShoppingListEntry>) {
+        if(p.vm.uiState.offlineState.isOffline) {
+            if(entries.all { entry -> entry.checked }) {
+                vm.executeOfflineAction(entries, ShoppingListEntryOfflineActions.UNCHECK)
+            } else {
+                vm.executeOfflineAction(entries, ShoppingListEntryOfflineActions.CHECK)
+            }
+
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentTick)
+        } else {
+            coroutineScope.launch {
+                actionRequestState.wrapRequest {
+                    if(entries.all { entry -> entry.checked }) {
+                        client?.shopping?.uncheck(entries)
+                    } else {
+                        client?.shopping?.check(entries)
+                    }
+
+                    vm.renderItems()
+                    vm.update()
+                }
+
+                hapticFeedback.handleTandoorRequestState(actionRequestState)
+            }
+        }
     }
 
     Scaffold(
@@ -328,6 +357,11 @@ fun RouteMainSubrouteShopping(
                                                     shoppingListEntryDetailsBottomSheetState.open(
                                                         item.entries
                                                     )
+                                                },
+                                                onDoubleClick = {
+                                                    if (allowDoubleClickCheck) {
+                                                        checkEntries(item.entries)
+                                                    }
                                                 }
                                             )
                                         }
@@ -460,31 +494,7 @@ fun RouteMainSubrouteShopping(
             state = shoppingListEntryDetailsBottomSheetState,
             isOffline = p.vm.uiState.offlineState.isOffline,
             onCheck = { entries ->
-                if(p.vm.uiState.offlineState.isOffline) {
-                    if(entries.all { entry -> entry.checked }) {
-                        vm.executeOfflineAction(entries, ShoppingListEntryOfflineActions.UNCHECK)
-                    } else {
-                        vm.executeOfflineAction(entries, ShoppingListEntryOfflineActions.CHECK)
-                    }
-
-                    hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentTick)
-                    return@ShoppingListEntryDetailsBottomSheet
-                }
-
-                coroutineScope.launch {
-                    actionRequestState.wrapRequest {
-                        if(entries.all { entry -> entry.checked }) {
-                            client.shopping.uncheck(entries)
-                        } else {
-                            client.shopping.check(entries)
-                        }
-
-                        vm.renderItems()
-                        vm.update()
-                    }
-
-                    hapticFeedback.handleTandoorRequestState(actionRequestState)
-                }
+                checkEntries(entries)
             },
             onDelete = { entries ->
                 if(p.vm.uiState.offlineState.isOffline) {

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsBehavior.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsBehavior.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.Numbers
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Share
+import androidx.compose.material.icons.rounded.ShoppingCartCheckout
 import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material.icons.rounded.WarningAmber
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -58,6 +59,8 @@ import kitshn.composeapp.generated.resources.settings_section_behavior_promote_t
 import kitshn.composeapp.generated.resources.settings_section_behavior_promote_tomorrows_meal_plan_label
 import kitshn.composeapp.generated.resources.settings_section_behavior_properties_show_fractional_values_description
 import kitshn.composeapp.generated.resources.settings_section_behavior_properties_show_fractional_values_label
+import kitshn.composeapp.generated.resources.settings_section_behavior_shopping_item_double_click_check_description
+import kitshn.composeapp.generated.resources.settings_section_behavior_shopping_item_double_click_check_label
 import kitshn.composeapp.generated.resources.settings_section_behavior_use_share_wrapper_description
 import kitshn.composeapp.generated.resources.settings_section_behavior_use_share_wrapper_label
 import kotlinx.coroutines.launch
@@ -236,6 +239,21 @@ fun ViewSettingsBehavior(
                 ) {
                     coroutineScope.launch {
                         p.vm.settings.setPropertiesShowFractionalValues(it)
+                    }
+                }
+            }
+
+            item {
+                SettingsSwitchListItem(
+                    position = SettingsListItemPosition.SINGULAR,
+                    label = { Text(stringResource(Res.string.settings_section_behavior_shopping_item_double_click_check_label)) },
+                    description = { Text(stringResource(Res.string.settings_section_behavior_shopping_item_double_click_check_description)) },
+                    icon = Icons.Rounded.ShoppingCartCheckout,
+                    contentDescription = stringResource(Res.string.settings_section_behavior_shopping_item_double_click_check_label),
+                    checked = propertiesShowFractionalValues.value
+                ) { checked ->
+                    coroutineScope.launch {
+                        p.vm.settings.setShoppingItemDoubleClickCheck(checked)
                     }
                 }
             }


### PR DESCRIPTION
This is an easy addition that adds double clicks checks to the shopping list items in the regular shopping list view. 

Resolves https://github.com/aimok04/kitshn/issues/380

I also added a setting to toggle this feature on and off but I enabled it per default