### PR TITLE
fix: FAP recipe view overlaying

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
@@ -456,11 +456,10 @@ fun ViewRecipeDetails(
         )
 
         Box(
-            Modifier.fillMaxWidth()
-                .padding(bottom = 16.dp),
+            Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center
         ) {
-            if((recipe?.source_url ?: "").isNotBlank()) OutlinedButton(
+            OutlinedButton(
                 onClick = {
                     try {
                         websiteHandler(recipe?.source_url!!)
@@ -1021,10 +1020,14 @@ fun ViewRecipeDetails(
                 showFractionalValues = propertiesShowFractionalValues.value
             )
 
-            if(notEnoughSpace && (recipe?.source_url ?: "").isNotBlank()) {
-                SourceButton()
-            } else {
-                Spacer(Modifier.height(70.dp))
+            if(notEnoughSpace){
+                Box(modifier = Modifier.height(48.dp)){
+                    if((recipe?.source_url ?: "").isNotBlank()){
+                        SourceButton()
+                    }
+                }
+                // add spacer against for FAP overlay
+                Spacer(Modifier.height(48.dp))
             }
         }
 


### PR DESCRIPTION
Small fix to the bottom padding / spacing of recipes so it does not overlay with recipe content

 
<img width="1080" height="1232" alt="Screenshot_20260415-201511_edited" src="https://github.com/user-attachments/assets/72d5c8a8-d2ea-4438-8b8d-e01a6917359c" />
<img width="1080" height="1272" alt="Screenshot_20260415-201703_edited" src="https://github.com/user-attachments/assets/dfc3b3d0-2003-4bf2-939a-8d9cdc4614c1" />
