### PR TITLE
Hide and Pin Search & Bottom Bar options

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -392,6 +392,8 @@
     <string name="settings_section_appearance_follow_system_label">Follow system</string>
     <string name="settings_section_appearance_hide_activity_label">Hide activity section</string>
     <string name="settings_section_appearance_hide_activity_description">Hides the activity section in the recipe details view</string>
+    <string name="settings_section_appearance_hide_bottom_bar_on_scroll_description">Hides the bottom navigation bar when scrolling down</string>
+    <string name="settings_section_appearance_hide_bottom_bar_on_scroll_label">Hide bottom bar on scroll</string>
     <string name="settings_section_appearance_label">Appearance</string>
     <string name="settings_section_behavior_description">Change kitshn's behavior</string>
     <string name="settings_section_behavior_enable_crash_reporting">Enable crash reporting</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -394,6 +394,8 @@
     <string name="settings_section_appearance_hide_activity_description">Hides the activity section in the recipe details view</string>
     <string name="settings_section_appearance_hide_bottom_bar_on_scroll_description">Hides the bottom navigation bar when scrolling down</string>
     <string name="settings_section_appearance_hide_bottom_bar_on_scroll_label">Hide bottom bar on scroll</string>
+    <string name="settings_section_appearance_pin_home_search_bar_description">Keeps the search bar at the top on the home tab</string>
+    <string name="settings_section_appearance_pin_home_search_bar_label">Pin home search bar</string>
     <string name="settings_section_appearance_label">Appearance</string>
     <string name="settings_section_behavior_description">Change kitshn's behavior</string>
     <string name="settings_section_behavior_enable_crash_reporting">Enable crash reporting</string>

--- a/shared/src/commonMain/kotlin/de/kitshn/Settings.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/Settings.kt
@@ -26,6 +26,7 @@ const val KEY_SETTINGS_APPEARANCE_COLOR_SCHEME = "appearance_color_scheme"
 const val KEY_SETTINGS_APPEARANCE_CUSTOM_COLOR_SCHEME_SEED = "appearance_custom_color_scheme_seed"
 const val KEY_SETTINGS_APPEARANCE_ENLARGE_SHOPPING_MODE = "appearance_enlarge_shopping_mode"
 const val KEY_SETTINGS_APPEARANCE_HIDE_ACTIVITY = "appearance_hide_activity"
+const val KEY_SETTINGS_APPEARANCE_HIDE_BOTTOM_BAR_ON_SCROLL = "appearance_hide_bottom_bar_on_scroll"
 
 const val KEY_SETTINGS_BEHAVIOR_USE_SHARE_WRAPPER = "behavior_use_share_wrapper"
 const val KEY_SETTINGS_BEHAVIOR_USE_SHARE_WRAPPER_HINT_SHOWN =
@@ -154,6 +155,12 @@ class SettingsViewModel : ViewModel() {
 
     fun setHideActivity(hide: Boolean) =
         obs.putBoolean(KEY_SETTINGS_APPEARANCE_HIDE_ACTIVITY, hide)
+
+    val getHideBottomBarOnScroll: Flow<Boolean> =
+        obs.getBooleanFlow(KEY_SETTINGS_APPEARANCE_HIDE_BOTTOM_BAR_ON_SCROLL, false)
+
+    fun setHideBottomBarOnScroll(hide: Boolean) =
+        obs.putBoolean(KEY_SETTINGS_APPEARANCE_HIDE_BOTTOM_BAR_ON_SCROLL, hide)
 
     // behavior
     val getUseShareWrapper: Flow<Boolean> =

--- a/shared/src/commonMain/kotlin/de/kitshn/Settings.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/Settings.kt
@@ -27,6 +27,7 @@ const val KEY_SETTINGS_APPEARANCE_CUSTOM_COLOR_SCHEME_SEED = "appearance_custom_
 const val KEY_SETTINGS_APPEARANCE_ENLARGE_SHOPPING_MODE = "appearance_enlarge_shopping_mode"
 const val KEY_SETTINGS_APPEARANCE_HIDE_ACTIVITY = "appearance_hide_activity"
 const val KEY_SETTINGS_APPEARANCE_HIDE_BOTTOM_BAR_ON_SCROLL = "appearance_hide_bottom_bar_on_scroll"
+const val KEY_SETTINGS_APPEARANCE_PIN_HOME_SEARCH_BAR = "appearance_pin_home_search_bar"
 
 const val KEY_SETTINGS_BEHAVIOR_USE_SHARE_WRAPPER = "behavior_use_share_wrapper"
 const val KEY_SETTINGS_BEHAVIOR_USE_SHARE_WRAPPER_HINT_SHOWN =
@@ -161,6 +162,12 @@ class SettingsViewModel : ViewModel() {
 
     fun setHideBottomBarOnScroll(hide: Boolean) =
         obs.putBoolean(KEY_SETTINGS_APPEARANCE_HIDE_BOTTOM_BAR_ON_SCROLL, hide)
+
+    val getPinHomeSearchBar: Flow<Boolean> =
+        obs.getBooleanFlow(KEY_SETTINGS_APPEARANCE_PIN_HOME_SEARCH_BAR, false)
+
+    fun setPinHomeSearchBar(pin: Boolean) =
+        obs.putBoolean(KEY_SETTINGS_APPEARANCE_PIN_HOME_SEARCH_BAR, pin)
 
     // behavior
     val getUseShareWrapper: Flow<Boolean> =

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/component/ScrollToHideConnection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/component/ScrollToHideConnection.kt
@@ -33,8 +33,38 @@ fun rememberScrollToHideConnection(
                 if ((delta > 0 && scrollDelta < 0) || (delta < 0 && scrollDelta > 0)) {
                     scrollDelta = 0f
                 }
+
+                // Restart show job on any interaction
+                if (source == NestedScrollSource.UserInput) {
+                    showJob?.cancel()
+                    showJob = scope.launch {
+                        delay(600)
+                        onShow()
+                        scrollDelta = 0f
+                    }
+                }
+
+                return super.onPreScroll(available, source)
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource
+            ): Offset {
+                if (!enabled) return super.onPostScroll(consumed, available, source)
+
+                // Only accumulate downward scroll if content actually moved
+                // (prevents hiding at the bottom of a list or when not scrollable)
+                if (consumed.y < 0) {
+                    scrollDelta += consumed.y
+                } 
                 
-                scrollDelta += delta
+                // Accumulate upward scroll (consumed OR available/overscroll at the top)
+                // ensures the bar shows even when the content is already at the top.
+                if (consumed.y > 0 || available.y > 0) {
+                    scrollDelta += (consumed.y + available.y)
+                }
 
                 if (scrollDelta < -20f) { // Significant scroll down
                     showJob?.cancel()
@@ -46,17 +76,7 @@ fun rememberScrollToHideConnection(
                     scrollDelta = 0f
                 }
 
-                // Show after delay if scrolling stopped during user input
-                if (source == NestedScrollSource.UserInput) {
-                    showJob?.cancel()
-                    showJob = scope.launch {
-                        delay(600)
-                        onShow()
-                        scrollDelta = 0f
-                    }
-                }
-
-                return super.onPreScroll(available, source)
+                return super.onPostScroll(consumed, available, source)
             }
 
             override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/component/ScrollToHideConnection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/component/ScrollToHideConnection.kt
@@ -1,0 +1,66 @@
+package de.kitshn.ui.component
+
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun rememberScrollToHideConnection(
+    state: NavigationSuiteScaffoldState,
+    enabled: Boolean
+): NestedScrollConnection {
+    val scope = rememberCoroutineScope()
+    
+    return remember(state, enabled) {
+        var showJob: Job? = null
+        var scrollDelta = 0f
+
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (!enabled) return super.onPreScroll(available, source)
+
+                val delta = available.y
+                scrollDelta += delta
+
+                if (scrollDelta < -20f) { // Significant scroll down
+                    showJob?.cancel()
+                    scope.launch { state.hide() }
+                    scrollDelta = 0f
+                } else if (scrollDelta > 20f) { // Significant scroll up
+                    showJob?.cancel()
+                    scope.launch { state.show() }
+                    scrollDelta = 0f
+                }
+
+                // Show after delay if scrolling stopped during user input
+                if (source == NestedScrollSource.UserInput) {
+                    showJob?.cancel()
+                    showJob = scope.launch {
+                        delay(600)
+                        state.show()
+                        scrollDelta = 0f
+                    }
+                }
+
+                return super.onPreScroll(available, source)
+            }
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                if (enabled) {
+                    showJob?.cancel()
+                    state.show()
+                    scrollDelta = 0f
+                }
+                return super.onPostFling(consumed, available)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/component/ScrollToHideConnection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/component/ScrollToHideConnection.kt
@@ -1,6 +1,5 @@
 package de.kitshn.ui.component
 
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -14,12 +13,13 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun rememberScrollToHideConnection(
-    state: NavigationSuiteScaffoldState,
-    enabled: Boolean
+    enabled: Boolean,
+    onHide: suspend () -> Unit,
+    onShow: suspend () -> Unit
 ): NestedScrollConnection {
     val scope = rememberCoroutineScope()
     
-    return remember(state, enabled) {
+    return remember(enabled) {
         var showJob: Job? = null
         var scrollDelta = 0f
 
@@ -28,15 +28,21 @@ fun rememberScrollToHideConnection(
                 if (!enabled) return super.onPreScroll(available, source)
 
                 val delta = available.y
+                
+                // Reset accumulation on direction change
+                if ((delta > 0 && scrollDelta < 0) || (delta < 0 && scrollDelta > 0)) {
+                    scrollDelta = 0f
+                }
+                
                 scrollDelta += delta
 
                 if (scrollDelta < -20f) { // Significant scroll down
                     showJob?.cancel()
-                    scope.launch { state.hide() }
+                    scope.launch { onHide() }
                     scrollDelta = 0f
                 } else if (scrollDelta > 20f) { // Significant scroll up
                     showJob?.cancel()
-                    scope.launch { state.show() }
+                    scope.launch { onShow() }
                     scrollDelta = 0f
                 }
 
@@ -45,7 +51,7 @@ fun rememberScrollToHideConnection(
                     showJob?.cancel()
                     showJob = scope.launch {
                         delay(600)
-                        state.show()
+                        onShow()
                         scrollDelta = 0f
                     }
                 }
@@ -56,7 +62,7 @@ fun rememberScrollToHideConnection(
             override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
                 if (enabled) {
                     showJob?.cancel()
-                    state.show()
+                    onShow()
                     scrollDelta = 0f
                 }
                 return super.onPostFling(consumed, available)

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/route/main/Main.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/route/main/Main.kt
@@ -14,19 +14,25 @@ import androidx.compose.material.icons.rounded.ShoppingCart
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldValue
+import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import de.kitshn.saveBreadcrumb
+import de.kitshn.ui.component.rememberScrollToHideConnection
 import de.kitshn.ui.dialog.version.TandoorBetaInfoDialog
 import de.kitshn.ui.dialog.version.TandoorServerVersionCompatibilityDialog
 import de.kitshn.ui.route.RouteParameters
@@ -37,6 +43,7 @@ import kitshn.shared.generated.resources.navigation_home
 import kitshn.shared.generated.resources.navigation_meal_plan
 import kitshn.shared.generated.resources.navigation_settings
 import kitshn.shared.generated.resources.navigation_shopping
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -79,6 +86,17 @@ fun RouteMain(p: RouteParameters) {
     var currentDestination by rememberSaveable { mutableStateOf(AppDestinations.HOME) }
     val mainSubNavHostController = rememberAlternateNavController()
 
+    val scaffoldState = rememberNavigationSuiteScaffoldState()
+    val scope = rememberCoroutineScope()
+
+    val hideBottomBarOnScroll =
+        p.vm.settings.getHideBottomBarOnScroll.collectAsState(initial = false)
+
+    val nestedScrollConnection = rememberScrollToHideConnection(
+        state = scaffoldState,
+        enabled = hideBottomBarOnScroll.value
+    )
+
     val destination by mainSubNavHostController.currentBackStackEntryAsState()
     LaunchedEffect(destination) {
         val route = destination?.destination?.route ?: ""
@@ -88,12 +106,19 @@ fun RouteMain(p: RouteParameters) {
             if(!route.startsWith(it.route)) return@forEach
             currentDestination = it
         }
+
+        // Show bottom bar when destination changes
+        if (scaffoldState.currentValue == NavigationSuiteScaffoldValue.Hidden) {
+            scope.launch { scaffoldState.show() }
+        }
     }
 
     val isOffline = p.vm.uiState.offlineState.isOffline
 
     NavigationSuiteScaffold(
-        navigationSuiteColors = NavigationSuiteDefaults.colors(
+        state = scaffoldState,
+        modifier = Modifier.nestedScroll(nestedScrollConnection),
+        navigationSuiteColors = androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults.colors(
             navigationRailContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest
         ),
         navigationSuiteItems = {

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/route/main/Main.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/route/main/Main.kt
@@ -93,8 +93,9 @@ fun RouteMain(p: RouteParameters) {
         p.vm.settings.getHideBottomBarOnScroll.collectAsState(initial = false)
 
     val nestedScrollConnection = rememberScrollToHideConnection(
-        state = scaffoldState,
-        enabled = hideBottomBarOnScroll.value
+        enabled = hideBottomBarOnScroll.value,
+        onHide = { scaffoldState.hide() },
+        onShow = { scaffoldState.show() }
     )
 
     val destination by mainSubNavHostController.currentBackStackEntryAsState()

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/home/Home.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/route/main/subroute/home/Home.kt
@@ -113,7 +113,11 @@ fun RouteMainSubrouteHome(
 
     val selectionModeState = rememberSelectionModeState<Int>()
 
-    val searchBarScrollBehavior = SearchBarDefaults.enterAlwaysSearchBarScrollBehavior()
+    val pinHomeSearchBar by p.vm.settings.getPinHomeSearchBar.collectAsState(initial = false)
+
+    val searchBarScrollBehavior = SearchBarDefaults.enterAlwaysSearchBarScrollBehavior(
+        canScroll = { !pinHomeSearchBar }
+    )
 
     var isScrollingUp by rememberSaveable { mutableStateOf(true) }
 

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAppearance.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAppearance.kt
@@ -7,12 +7,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.ViewList
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.CommentsDisabled
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.Loupe
 import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.PushPin
+import androidx.compose.material.icons.rounded.UnfoldLess
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -209,7 +210,7 @@ fun ViewSettingsAppearance(
                     position = SettingsListItemPosition.TOP,
                     label = { Text(stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_label)) },
                     description = { Text(stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_description)) },
-                    icon = Icons.AutoMirrored.Rounded.ViewList,
+                    icon = Icons.Rounded.UnfoldLess,
                     contentDescription = stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_label),
                     checked = hideBottomBarOnScroll.value
                 ) {
@@ -226,7 +227,7 @@ fun ViewSettingsAppearance(
                     position = SettingsListItemPosition.BOTTOM,
                     label = { Text(stringResource(Res.string.settings_section_appearance_pin_home_search_bar_label)) },
                     description = { Text(stringResource(Res.string.settings_section_appearance_pin_home_search_bar_description)) },
-                    icon = Icons.Rounded.Loupe,
+                    icon = Icons.Rounded.PushPin,
                     contentDescription = stringResource(Res.string.settings_section_appearance_pin_home_search_bar_label),
                     checked = pinHomeSearchBar.value
                 ) {

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAppearance.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAppearance.kt
@@ -56,6 +56,8 @@ import kitshn.shared.generated.resources.settings_section_appearance_hide_activi
 import kitshn.shared.generated.resources.settings_section_appearance_hide_activity_label
 import kitshn.shared.generated.resources.settings_section_appearance_hide_bottom_bar_on_scroll_description
 import kitshn.shared.generated.resources.settings_section_appearance_hide_bottom_bar_on_scroll_label
+import kitshn.shared.generated.resources.settings_section_appearance_pin_home_search_bar_description
+import kitshn.shared.generated.resources.settings_section_appearance_pin_home_search_bar_label
 import kitshn.shared.generated.resources.settings_section_appearance_label
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -204,7 +206,7 @@ fun ViewSettingsAppearance(
                 val hideBottomBarOnScroll = p.vm.settings.getHideBottomBarOnScroll.collectAsState(initial = false)
 
                 SettingsSwitchListItem(
-                    position = SettingsListItemPosition.SINGULAR,
+                    position = SettingsListItemPosition.TOP,
                     label = { Text(stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_label)) },
                     description = { Text(stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_description)) },
                     icon = Icons.AutoMirrored.Rounded.ViewList,
@@ -213,6 +215,23 @@ fun ViewSettingsAppearance(
                 ) {
                     coroutineScope.launch {
                         p.vm.settings.setHideBottomBarOnScroll(it)
+                    }
+                }
+            }
+
+            item {
+                val pinHomeSearchBar = p.vm.settings.getPinHomeSearchBar.collectAsState(initial = false)
+
+                SettingsSwitchListItem(
+                    position = SettingsListItemPosition.BOTTOM,
+                    label = { Text(stringResource(Res.string.settings_section_appearance_pin_home_search_bar_label)) },
+                    description = { Text(stringResource(Res.string.settings_section_appearance_pin_home_search_bar_description)) },
+                    icon = Icons.Rounded.Loupe,
+                    contentDescription = stringResource(Res.string.settings_section_appearance_pin_home_search_bar_label),
+                    checked = pinHomeSearchBar.value
+                ) {
+                    coroutineScope.launch {
+                        p.vm.settings.setPinHomeSearchBar(it)
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAppearance.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsAppearance.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ViewList
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.CommentsDisabled
 import androidx.compose.material.icons.rounded.DarkMode
@@ -53,6 +54,8 @@ import kitshn.shared.generated.resources.settings_section_appearance_follow_syst
 import kitshn.shared.generated.resources.settings_section_appearance_follow_system_label
 import kitshn.shared.generated.resources.settings_section_appearance_hide_activity_description
 import kitshn.shared.generated.resources.settings_section_appearance_hide_activity_label
+import kitshn.shared.generated.resources.settings_section_appearance_hide_bottom_bar_on_scroll_description
+import kitshn.shared.generated.resources.settings_section_appearance_hide_bottom_bar_on_scroll_label
 import kitshn.shared.generated.resources.settings_section_appearance_label
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -193,6 +196,23 @@ fun ViewSettingsAppearance(
                 ) {
                     coroutineScope.launch {
                         p.vm.settings.setHideActivity(it)
+                    }
+                }
+            }
+
+            item {
+                val hideBottomBarOnScroll = p.vm.settings.getHideBottomBarOnScroll.collectAsState(initial = false)
+
+                SettingsSwitchListItem(
+                    position = SettingsListItemPosition.SINGULAR,
+                    label = { Text(stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_label)) },
+                    description = { Text(stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_description)) },
+                    icon = Icons.AutoMirrored.Rounded.ViewList,
+                    contentDescription = stringResource(Res.string.settings_section_appearance_hide_bottom_bar_on_scroll_label),
+                    checked = hideBottomBarOnScroll.value
+                ) {
+                    coroutineScope.launch {
+                        p.vm.settings.setHideBottomBarOnScroll(it)
                     }
                 }
             }


### PR DESCRIPTION
This implements 
1. a option to allow the bottom bar to hide if scrolled down
2. a option to allow the search bar to pin and not hide to not scroll down 

! Both these changes are largely written by AI so I was lazy

But I think they are quite okay since I wanted to outsource the scroll connection to somewhere not in Main and Home.kt to not clutter them.