### PR TITLE
fix: datetime handling in mealplans

### DIFF
--- a/shared/src/commonMain/kotlin/de/kitshn/Utils.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/Utils.kt
@@ -35,16 +35,17 @@ import kitshn.shared.generated.resources.common_tomorrow
 import kitshn.shared.generated.resources.common_yesterday
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.format
+import kotlinx.datetime.atTime
+import kotlinx.datetime.daysUntil
 import kotlinx.datetime.format.FormatStringsInDatetimeFormats
 import kotlinx.datetime.format.byUnicodePattern
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.todayIn
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -55,6 +56,7 @@ import org.jetbrains.compose.resources.stringResource
 import kotlin.math.floor
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 enum class FileFormats(val extensions: List<String>, val mimeType: String) {
     EPUB(listOf("epub"), "application/epub+zip"),
@@ -302,9 +304,9 @@ fun String.parseIsoTime(): LocalDateTime {
 }
 
 fun LocalDate.toStartOfDayString(): String {
-    return this.atStartOfDayIn(TimeZone.currentSystemDefault())
-        .toLocalDateTime(TimeZone.UTC)
-        .format(LocalDateTime.Formats.ISO) + "Z"
+    return this.atTime(0,0,0)
+        .toInstant(TimeZone.UTC)
+        .toString()
 }
 
 fun Long.toLocalDate(
@@ -342,26 +344,23 @@ expect fun LocalDate.format(pattern: String): String
 
 @Composable
 fun LocalDate.toHumanReadableDateLabel(): String {
-    val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-    val diff = this.toEpochDays() - today.toEpochDays()
+    val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+    val diff = today.daysUntil(this)
 
-    var label = when(diff) {
-        2L -> stringResource(Res.string.common_day_after_tomorrow)
-        1L -> stringResource(Res.string.common_tomorrow)
-        0L -> stringResource(Res.string.common_today)
-        -1L -> stringResource(Res.string.common_yesterday)
-        -2L -> stringResource(Res.string.common_day_before_yesterday)
+    val label = when(diff) {
+        2 -> stringResource(Res.string.common_day_after_tomorrow)
+        1 -> stringResource(Res.string.common_tomorrow)
+        0 -> stringResource(Res.string.common_today)
+        -1 -> stringResource(Res.string.common_yesterday)
+        -2 -> stringResource(Res.string.common_day_before_yesterday)
         else -> { null }
     }
 
-    if(label == "null") label = null
 
-    return label ?: if(diff in 0L..6L) {
-        this.format("EEEE")
-    }else if(this.year == today.year) {
-        this.format("EE, dd. MMM")
-    } else {
-        this.format("dd. MMMM yyyy")
+    return label ?: when {
+        diff in 0..6 -> this.format("EEEE")
+        this.year == today.year -> this.format("EE, dd. MMM")
+        else -> this.format("dd. MMMM yyyy")
     }
 }
 

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsBehavior.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsBehavior.kt
@@ -71,7 +71,6 @@ import kitshn.shared.generated.resources.settings_section_behavior_shopping_item
 import kitshn.shared.generated.resources.settings_section_behavior_use_share_wrapper_description
 import kitshn.shared.generated.resources.settings_section_behavior_use_share_wrapper_label
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -79,6 +78,7 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable


### PR DESCRIPTION
Everybody hates timezones

This replaces datetime.Instant with time.Instant since the former is deprecated. But there are two fixes that I should explain in more detail

Lets start with an extreme example

Kitshn: Tokyo UTC+9
Tandoor: Berlin UTC+2

1. toStartOfDayString used to take the user timezone into account where i don't think it is quite clear if this is smart 

Given a date like 2026-04-15T10:00:00+09:00 it would cut of the time and convert it to UTC i.e
send  2026-04-**14**T15:00:00Z in a round trip this would be converted back to UTC+9 again to 15.04.2026 again but in the server it 14.04.2026.

Although the time is "more" correct with the timezone since we strictly look at the date
We should always send back 2026-04-15T00:00:00+00:00 even for the example.

Maybe I am just thinking wrong

```kt
fun LocalDate.toStartOfDayString(): String {
//    return this.atStartOfDayIn(TimeZone.currentSystemDefault())
//        .toLocalDateTime(TimeZone.UTC)
//        .format(LocalDateTime.Formats.ISO) + "Z"
    return this.atTime(0,0,0)
        .toInstant(TimeZone.UTC)
        .toString()
}
```

2.  This is more easy since it is just cleaner code. I don't know if the prior ones had bugs in some form, but the new one uses exactly the functions we need, so i am pretty sure about this one.