### PR TITLE
fix: add placeholder to step editor

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -295,6 +295,7 @@
     <string name="recipe_sorting_relevance">Relevanz</string>
     <string name="recipe_step_timer_created">Timer wurde erstellt.</string>
     <string name="recipe_step_timer_error_no_app">Du benötigst eine unterstützte Timer-App, um diese Aktion auszuführen!</string>
+    <string name="recipe_step_step_description">Füge Anweisungen für diesen Schritt hinzu</string>
     <string name="search_food_including_all_description">Die Rezepte müssen alle Zutaten beinhalten</string>
     <string name="search_food_including_all_label">Alle Zutaten beinhaltet</string>
     <string name="search_ingredients">Zutaten durchsuchen</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -420,4 +420,5 @@
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_description">Empêcher l'écran de se mettre en veille pendant l’affichage de la recette, tout comme dans le Mode cuisine</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_label">Gardez l’affichage de la recette actif</string>
     <string name="common_shopping_list">Liste de courses</string>
+    <string name="recipe_step_step_description">Ajoutez les instructions pour cette étape</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -344,6 +344,7 @@
     <string name="recipe_sorting_relevance">Relevance</string>
     <string name="recipe_step_timer_created">Timer has been created.</string>
     <string name="recipe_step_timer_error_no_app">You need to install a supported timer app for this action!</string>
+    <string name="recipe_step_step_description">Add instructions for this step</string>
 
     <string name="search_categories">Search categories</string>
     <string name="search_food_including_all_description">The recipes must include all ingredients</string>

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/editor/MarkdownEditor.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/editor/MarkdownEditor.kt
@@ -2,10 +2,14 @@ package de.kitshn.ui.component.editor
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
+import kitshn.composeapp.generated.resources.Res
+import kitshn.composeapp.generated.resources.recipe_step_step_description
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun MarkdownEditor(
@@ -14,7 +18,8 @@ fun MarkdownEditor(
     Column {
         RichTextEditor(
             state = state,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text(stringResource(Res.string.recipe_step_step_description)) },
         )
 
         MarkdownEditorRow(


### PR DESCRIPTION
Sorry to spam you with new pr, but I currently have some free time at evening and I am now somewhat accustomed to the source and want to divide into manageable distinct units.


This one is easy and simply adds a new placeholder to the step markdown editor, since when I first used the app I didn't even know, that this is where i put the instruction content.

In general i think it makes sense to tune the app more towards uses who are also not perfectly well known in Tandoor ecosystem, i.e. more help tags more explaining what things are.