### PR TITLE
OnboardingSignInBrowser: wipe localStorage and sessionStorage on first load

### DIFF
--- a/shared/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/OnboardingSignInBrowser.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/route/onboarding/OnboardingSignInBrowser.kt
@@ -112,7 +112,19 @@ fun RouteOnboardingSignInBrowser(
                     webViewState.cookieManager.removeAllCookies()
                 }
 
+                // Wipe localStorage / sessionStorage on the first load so a stale
+                // session indicator left behind by a previous sign-in attempt
+                // can't surface alongside the cleared cookies.
+                var storageCleared by remember { mutableStateOf(false) }
+
                 LaunchedEffect(webViewState.loadingState) {
+                    if(!storageCleared && webViewState.loadingState is LoadingState.Loading) {
+                        webViewNavigator.evaluateJavaScript(
+                            "try { localStorage.clear(); sessionStorage.clear(); } catch (e) {}"
+                        )
+                        storageCleared = true
+                    }
+
                     // needed for iOS because app gets denied (reason: https://developer.apple.com/app-store/review/guidelines/#login-services and https://developer.apple.com/app-store/review/guidelines/#data-collection-and-storage)
                     if(platformDetails.platform == Platforms.IOS) {
                         if(webViewState.lastLoadedUrl?.contains("accounts/signup") == true) {


### PR DESCRIPTION
Closes #403.

`OnboardingSignInBrowser` already calls `webViewState.cookieManager.removeAllCookies()` before loading the Tandoor sign-in page, but `localStorage` and `sessionStorage` for the instance origin survive the onboarding flow. If a user backs out of onboarding and re-enters, the previous page's storage state can briefly surface before re-authentication completes.

### Change

Inject a one-shot `localStorage.clear(); sessionStorage.clear();` through `webViewNavigator.evaluateJavaScript` the first time the WebView enters `LoadingState.Loading`. A `remember`-backed flag (`storageCleared`) prevents the inject from re-firing as sub-resources continue to load.

The cookie path (the authoritative one for Tandoor) is unchanged. The iOS-specific JS injection that follows in the same `LaunchedEffect` is unaffected.