### PR TITLE
Timer detection

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -392,20 +392,41 @@
     <string name="common_select_users_for_sharing_empty">Wähle Nutzer, mit denen du diesen Eintrag teilen möchtest.</string>
     <string name="search_users">Nutzer suchen</string>
     <string-array name="timer_detection_hour_definitions">
+        <item>stündchen</item>
         <item>stunden</item>
         <item>stunde</item>
+        <item>std.</item>
+        <item>std</item>
     </string-array>
     <string-array name="timer_detection_and_definitions">
         <item>und</item>
     </string-array>
     <string-array name="timer_detection_minute_definitions">
+        <item>minütchen</item>
         <item>minuten</item>
         <item>minute</item>
+        <item>min.</item>
         <item>mins</item>
         <item>min</item>
     </string-array>
+    <string-array name="timer_detection_second_definitions">
+        <item>sekündchen</item>
+        <item>sekunden</item>
+        <item>sekunde</item>
+        <item>sek.</item>
+        <item>sek</item>
+    </string-array>
     <string-array name="timer_detection_to_definitions">
         <item>bis</item>
+    </string-array>
+
+    <string-array name="timer_detection_range_qualifier_definitions">
+        <item>maximal</item>
+        <item>höchstens</item>
+        <item>mindestens</item>
+        <item>ungefähr</item>
+        <item>etwa</item>
+        <item>ca.</item>
     </string-array>
     <string name="error_outdated_v1_instance">Diese Version von kitshn unterstützt Tandoor v1 nicht. Bitte aktualisiere entweder auf Tandoor v2 oder installiere eine ältere Version von kitshn.</string>
     <string name="kofi_support_description">Du kannst die Entwicklung von kitshn auf Ko-Fi unterstützen</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -487,7 +487,24 @@
         <item>min</item>
     </string-array>
 
+    <string-array name="timer_detection_second_definitions">
+        <item>seconds</item>
+        <item>second</item>
+        <item>secs</item>
+        <item>sec</item>
+    </string-array>
+
     <string-array name="timer_detection_to_definitions">
         <item>to</item>
+    </string-array>
+
+    <string-array name="timer_detection_range_qualifier_definitions">
+        <item>about</item>
+        <item>around</item>
+        <item>approx</item>
+        <item>approximately</item>
+        <item>at most</item>
+        <item>at least</item>
+        <item>up to</item>
     </string-array>
 </resources>

--- a/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetection.kt
@@ -1,0 +1,100 @@
+package de.kitshn.time
+
+data class TimerDetectionDefs(
+    val hourDefs: Set<String>,
+    val andDefs: Set<String>,
+    val minuteDefs: Set<String>,
+    val secondDefs: Set<String>,
+    val rangeDefs: Set<String>,
+    val rangeQualifierDefs: Set<String> = emptySet()
+)
+
+private fun parseToSeconds(value: String, multiplier: Double): Int =
+    ((value.replace(',', '.').toDoubleOrNull() ?: 0.0) * multiplier).toInt()
+
+private fun Set<String>.toRegexAlt(): String =
+    sortedByDescending(String::length)
+        .joinToString("|") { Regex.escape(it) }
+
+fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
+
+    val hours = defs.hourDefs.toRegexAlt()
+    val minutes = defs.minuteDefs.toRegexAlt()
+    val seconds = defs.secondDefs.toRegexAlt()
+    val andWords = defs.andDefs.toRegexAlt()
+    val number = """[0-9]+(?:[.,][0-9]+)?"""
+    val unit = "$hours|$minutes|$seconds"
+
+    val qualifier = defs.rangeQualifierDefs
+        .takeIf(Set<String>::isNotEmpty)
+        ?.toRegexAlt()
+        ?.let { """(?:(?:$it)\s+)?""" }
+        .orEmpty()
+
+    val rangeSep = if (defs.rangeDefs.isNotEmpty()) {
+        val rangeWords = defs.rangeDefs.toRegexAlt()
+        """(?:\s*-\s*|\s+(?:$rangeWords)\s+$qualifier)"""
+    } else {
+        """\s*-\s*"""
+    }
+
+    val hourRegex = Regex("^($hours)$", RegexOption.IGNORE_CASE)
+    val minuteRegex = Regex("^($minutes)$", RegexOption.IGNORE_CASE)
+
+    fun unitMultiplier(u: String): Double = when {
+        hourRegex.matches(u) -> 3600.0
+        minuteRegex.matches(u) -> 60.0
+        else -> 1.0
+    }
+
+    // COMMENTS mode ignores literal whitespace/newlines so the pattern can be formatted.
+    val pattern = Regex(
+        """
+        # Cross-unit range: "15 Sekunden bis 45 Minuten"
+        (?<crossFrom>$number)\s*(?<crossFromUnit>$unit)(?!\w)
+        $rangeSep
+        (?<crossTo>$number)\s*(?<crossToUnit>$unit)(?!\w)
+
+        | # Same-unit range: "10-15 min" / "0.5 bis maximal 2,3h"
+        (?<sameFrom>$number)
+        $rangeSep
+        (?<sameTo>$number)\s*(?<sameUnit>$unit)(?!\w)
+
+        | # Hour + minute combo: "1h 30min" / "1 Stunde und 30 Minuten"
+        (?:(?<comboHours>$number)\s*(?:$hours)(?!\w)\s*(?:$andWords)?\s*)?
+        (?<comboMinutes>$number)\s*(?:$minutes)(?!\w)
+
+        | # Hours only: "2h" / "1 Stunde"
+        (?<hoursOnly>$number)\s*(?:$hours)(?!\w)
+
+        | # Seconds only: "45s" / "30 Sekündchen"
+        (?<secondsOnly>$number)\s*(?:$seconds)(?!\w)
+        """,
+        setOf(RegexOption.IGNORE_CASE, RegexOption.COMMENTS)
+    )
+
+    return markdown.replace(pattern) { m ->
+        fun named(n: String) = m.groups[n]?.value.orEmpty()
+        fun timer(s: Int) = "[**⏲ ${m.value}**](timer://$s)"
+        fun range(from: Int, to: Int) = "[**⏲ ${m.value}**](timer-range://$from/$to)"
+
+        when {
+            named("crossFrom").isNotBlank() -> range(
+                parseToSeconds(named("crossFrom"), unitMultiplier(named("crossFromUnit"))),
+                parseToSeconds(named("crossTo"), unitMultiplier(named("crossToUnit")))
+            )
+            named("sameFrom").isNotBlank() -> {
+                val mult = unitMultiplier(named("sameUnit"))
+                range(parseToSeconds(named("sameFrom"), mult), parseToSeconds(named("sameTo"), mult))
+            }
+            named("hoursOnly").isNotBlank() ->
+                timer(parseToSeconds(named("hoursOnly"), 3600.0))
+            named("secondsOnly").isNotBlank() ->
+                timer(parseToSeconds(named("secondsOnly"), 1.0))
+            else -> timer(
+                parseToSeconds(named("comboHours").ifBlank { "0" }, 3600.0) +
+                    parseToSeconds(named("comboMinutes").ifBlank { "0" }, 60.0)
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/de/kitshn/time/TimerFormatting.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/time/TimerFormatting.kt
@@ -1,0 +1,21 @@
+package de.kitshn.time
+
+import androidx.compose.runtime.Composable
+import kitshn.shared.generated.resources.Res
+import kitshn.shared.generated.resources.common_hour_short
+import kitshn.shared.generated.resources.common_minute_min
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun Int.formatTimerSeconds(): String {
+    val h = this / 3600
+    val m = (this % 3600) / 60
+    val s = this % 60
+    val hourStr = stringResource(Res.string.common_hour_short)
+    val minStr = stringResource(Res.string.common_minute_min)
+    return buildList {
+        if (h > 0) add("$h $hourStr")
+        if (m > 0) add("$m $minStr")
+        if (s > 0 || (h == 0 && m == 0)) add("${s}s")
+    }.joinToString(" ")
+}

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/component/MarkdownRichTextWithTimerDetection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/component/MarkdownRichTextWithTimerDetection.kt
@@ -26,10 +26,14 @@ import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownTypography
 import de.kitshn.isLaunchTimerHandlerImplemented
+import de.kitshn.time.TimerDetectionDefs
+import de.kitshn.time.detectTimers
 import kitshn.shared.generated.resources.Res
 import kitshn.shared.generated.resources.timer_detection_and_definitions
 import kitshn.shared.generated.resources.timer_detection_hour_definitions
 import kitshn.shared.generated.resources.timer_detection_minute_definitions
+import kitshn.shared.generated.resources.timer_detection_range_qualifier_definitions
+import kitshn.shared.generated.resources.timer_detection_second_definitions
 import kitshn.shared.generated.resources.timer_detection_to_definitions
 import org.jetbrains.compose.resources.getStringArray
 
@@ -40,13 +44,11 @@ class MarkdownUriHandler(
 ) : UriHandler {
     override fun openUri(uri: String) {
         if(uri.startsWith("timer://")) {
-            onTimerClick(uri.replaceFirst("timer://", "").toInt() * 60)
+            onTimerClick(uri.removePrefix("timer://").toInt())
             return
         } else if(uri.startsWith("timer-range://")) {
-            val components = uri.replaceFirst("timer-range://", "")
-                .split("/")
-
-            onTimerRangeClick(components[0].toInt() * 60, components[1].toInt() * 60)
+            val components = uri.removePrefix("timer-range://").split("/")
+            onTimerRangeClick(components[0].toInt(), components[1].toInt())
             return
         }
 
@@ -67,54 +69,22 @@ fun MarkdownRichTextWithTimerDetection(
     var md by remember { mutableStateOf("") }
     LaunchedEffect(markdown) {
         if(isLaunchTimerHandlerImplemented) {
-            val hourDefinitions = mutableSetOf(
-                "hours",
-                "hour"
-            ).apply { addAll(getStringArray(Res.array.timer_detection_hour_definitions)) }
-            val hourDefinitionsStr =
-                hourDefinitions.sortedByDescending { it.length }.joinToString("|")
-
-            val andDefinitions =
-                mutableSetOf("and").apply { addAll(getStringArray(Res.array.timer_detection_and_definitions)) }
-            val andDefinitionsStr =
-                andDefinitions.sortedByDescending { it.length }.joinToString("|")
-
-            val minuteDefinitions = mutableSetOf(
-                "minutes",
-                "minute",
-                "mins",
-                "min"
-            ).apply { addAll(getStringArray(Res.array.timer_detection_minute_definitions)) }
-            val minuteDefinitionsStr =
-                minuteDefinitions.sortedByDescending { it.length }.joinToString("|")
-
-            val rangeDefinitions =
-                mutableSetOf(" ?- ?").apply { addAll(getStringArray(Res.array.timer_detection_to_definitions).map { " $it " }) }
-            val rangeDefinitionsStr =
-                rangeDefinitions.sortedByDescending { it.length }.joinToString("|")
-
-            md = markdown.replace(
-                Regex(
-                    "([0-9]+)(?:$rangeDefinitionsStr)([0-9]+) ?(?:$minuteDefinitionsStr)|(?:([0-9]+) ?(?:$hourDefinitionsStr) ?(?:$andDefinitionsStr)? ?)?([0-9]+) ?(?:$minuteDefinitionsStr)|([0-9]+) ?(?:$hourDefinitionsStr)",
-                    RegexOption.IGNORE_CASE
-                )
-            ) {
-                if(it.groupValues[1].isNotBlank()) {
-                    val fromMinutes = it.groupValues[1].toInt()
-                    val toMinutes = it.groupValues[2].toInt()
-
-                    "[**⏲ ${it.value}**](timer-range://$fromMinutes/$toMinutes)"
-                } else {
-                    val hours =
-                        it.groupValues[2].ifBlank { "0" }
-                            .toInt() + it.groupValues[5].ifBlank { "0" }
-                            .toInt()
-                    val minutes = it.groupValues[4].ifBlank { "0" }.toInt()
-
-                    val totalMinutes = (hours * 60) + minutes
-                    "[**⏲ ${it.value}**](timer://$totalMinutes)"
-                }
-            }
+            val defs = TimerDetectionDefs(
+                hourDefs = mutableSetOf("h", "hr", "hrs", "hour", "hours")
+                    .apply { addAll(getStringArray(Res.array.timer_detection_hour_definitions)) },
+                andDefs = mutableSetOf<String>()
+                    .apply { addAll(getStringArray(Res.array.timer_detection_and_definitions)) },
+                minuteDefs = mutableSetOf("min", "mins", "minute", "minutes")
+                    .apply { addAll(getStringArray(Res.array.timer_detection_minute_definitions)) },
+                secondDefs = mutableSetOf("s", "sec", "secs", "second", "seconds")
+                    .apply { addAll(getStringArray(Res.array.timer_detection_second_definitions)) },
+                rangeDefs = mutableSetOf<String>()
+                    .apply { addAll(getStringArray(Res.array.timer_detection_to_definitions)) },
+                rangeQualifierDefs = mutableSetOf(
+                    "about", "around", "approx", "approximately", "at most", "at least", "up to"
+                ).apply { addAll(getStringArray(Res.array.timer_detection_range_qualifier_definitions)) }
+            )
+            md = detectTimers(markdown, defs)
         } else {
             md = markdown
         }

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/LaunchTimerRangeBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/LaunchTimerRangeBottomSheet.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import de.kitshn.formatDuration
+import de.kitshn.time.formatTimerSeconds
 import kitshn.shared.generated.resources.Res
 import kitshn.shared.generated.resources.action_continue
 import kotlinx.coroutines.launch
@@ -81,26 +81,28 @@ fun LaunchTimerRangeBottomSheet(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                // Use minute granularity when the range ends at 2+ minutes,
-                // otherwise let the user pick individual seconds.
-                val inMinutes = state.to.value >= 120
-
-                val fromUnit = if(inMinutes) state.from.value / 60 else state.from.value
-                val toUnit = if(inMinutes) state.to.value / 60 else state.to.value
-                val initUnit = if(inMinutes) state.value / 60 else state.value
-                val sliderSteps = maxOf(0, toUnit - fromUnit - 1)
+                // Three-tier granularity: ≤2min → 1s steps, <1h → 1min steps, ≥1h → 30min steps
+                val stepSize = when {
+                    state.to.value <= 120 -> 1
+                    state.to.value < 3600 -> 60
+                    else -> 720
+                }
+                val fromStep = state.from.value / stepSize
+                val toStep = state.to.value / stepSize
+                val initStep = state.value / stepSize
+                val sliderSteps = maxOf(0, toStep - fromStep - 1)
 
                 val sliderState = rememberSliderState(
-                    value = initUnit.toFloat(),
+                    value = initStep.toFloat(),
                     steps = sliderSteps,
-                    valueRange = fromUnit.toFloat()..toUnit.toFloat(),
+                    valueRange = fromStep.toFloat()..toStep.toFloat(),
                 )
 
                 AnimatedContent(
-                    targetState = sliderState.value.roundToInt()
-                ) { value ->
+                    targetState = sliderState.value.roundToInt() * stepSize
+                ) { selectedSeconds ->
                     Text(
-                        text = "⏲ ${if(inMinutes) value.formatDuration() else "$value s"}",
+                        text = "⏲ ${selectedSeconds.formatTimerSeconds()}",
                         color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.displaySmall
                     )
@@ -114,9 +116,7 @@ fun LaunchTimerRangeBottomSheet(
                         coroutineScope.launch {
                             sheetState.hide()
                             state.dismiss()
-
-                            val selected = sliderState.value.roundToInt()
-                            state.callback(if(inMinutes) selected * 60 else selected)
+                            state.callback(sliderState.value.roundToInt() * stepSize)
                         }
                     }
                 ) {

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/LaunchTimerRangeBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/LaunchTimerRangeBottomSheet.kt
@@ -81,11 +81,11 @@ fun LaunchTimerRangeBottomSheet(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                // Three-tier granularity: ≤2min → 1s steps, <1h → 1min steps, ≥1h → 30min steps
+                // Range <=2min in 1s steps, <1h in 1min steps, >=1h in 15min steps
                 val stepSize = when {
                     state.to.value <= 120 -> 1
                     state.to.value < 3600 -> 60
-                    else -> 720
+                    else -> 900
                 }
                 val fromStep = state.from.value / stepSize
                 val toStep = state.to.value / stepSize

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/LaunchTimerRangeBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/LaunchTimerRangeBottomSheet.kt
@@ -15,11 +15,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberSliderState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -42,20 +40,18 @@ class LaunchTimerRangeBottomSheetState(
     val from: MutableState<Int> = mutableStateOf(0),
     val to: MutableState<Int> = mutableStateOf(0)
 ) {
-    var value by mutableStateOf(0)
-
-    var callback: (value: Int) -> Unit = {}
+    var value = 0
+    var callback: (seconds: Int) -> Unit = {}
 
     fun open(
         from: Int,
         to: Int,
-        callback: (value: Int) -> Unit
+        callback: (seconds: Int) -> Unit
     ) {
         this.shown.value = true
-        this.from.value = (from / 60)
-        this.to.value = (to / 60)
-
-        this.value = this.from.value + ((this.to.value - this.from.value) / 2)
+        this.from.value = from
+        this.to.value = to
+        this.value = from + (to - from) / 2
         this.callback = callback
     }
 
@@ -76,35 +72,41 @@ fun LaunchTimerRangeBottomSheet(
 
         ModalBottomSheet(
             sheetState = sheetState,
-            onDismissRequest = {
-                state.dismiss()
-            }
+            onDismissRequest = { state.dismiss() }
         ) {
             Column(
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier
+                    .padding(16.dp)
                     .fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
+                // Use minute granularity when the range ends at 2+ minutes,
+                // otherwise let the user pick individual seconds.
+                val inMinutes = state.to.value >= 120
+
+                val fromUnit = if(inMinutes) state.from.value / 60 else state.from.value
+                val toUnit = if(inMinutes) state.to.value / 60 else state.to.value
+                val initUnit = if(inMinutes) state.value / 60 else state.value
+                val sliderSteps = maxOf(0, toUnit - fromUnit - 1)
+
                 val sliderState = rememberSliderState(
-                    value = state.value.toFloat(),
-                    steps = (state.to.value - state.from.value) - 1,
-                    valueRange = state.from.value.toFloat()..state.to.value.toFloat(),
+                    value = initUnit.toFloat(),
+                    steps = sliderSteps,
+                    valueRange = fromUnit.toFloat()..toUnit.toFloat(),
                 )
 
                 AnimatedContent(
                     targetState = sliderState.value.roundToInt()
-                ) {
+                ) { value ->
                     Text(
-                        text = "⏲ ${it.formatDuration()}",
+                        text = "⏲ ${if(inMinutes) value.formatDuration() else "$value s"}",
                         color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.displaySmall
                     )
                 }
 
-                Slider(
-                    state = sliderState
-                )
+                Slider(state = sliderState)
 
                 Button(
                     modifier = Modifier.fillMaxWidth(),
@@ -113,7 +115,8 @@ fun LaunchTimerRangeBottomSheet(
                             sheetState.hide()
                             state.dismiss()
 
-                            state.callback(sliderState.value.roundToInt() * 60)
+                            val selected = sliderState.value.roundToInt()
+                            state.callback(if(inMinutes) selected * 60 else selected)
                         }
                     }
                 ) {

--- a/shared/src/commonTest/kotlin/de/kitshn/time/TimerDetectionTest.kt
+++ b/shared/src/commonTest/kotlin/de/kitshn/time/TimerDetectionTest.kt
@@ -1,0 +1,151 @@
+package de.kitshn.time
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TimerDetectionTest {
+
+    private val defs = TimerDetectionDefs(
+        hourDefs = setOf(
+            "h", "hr", "hrs", "hour", "hours",
+            "stündchen", "stunden", "stunde", "std.", "std"
+        ),
+        andDefs = setOf("and", "und"),
+        minuteDefs = setOf(
+            "min", "mins", "minute", "minutes",
+            "minütchen", "minuten", "min."
+        ),
+        secondDefs = setOf(
+            "s", "sec", "secs", "second", "seconds",
+            "sekündchen", "sekunden", "sekunde", "sek.", "sek"
+        ),
+        rangeDefs = setOf("to", "bis"),
+        rangeQualifierDefs = setOf(
+            "maximal", "höchstens", "mindestens", "ungefähr", "etwa", "ca.",
+            "about", "around", "approx", "approximately", "at most", "at least", "up to"
+        )
+    )
+
+    private fun String.timerUris(): List<String> =
+        Regex("""\(timer[^)]+\)""").findAll(detectTimers(this, defs)).map { it.value }.toList()
+
+    private fun String.singleUri() = timerUris().also {
+        assertEquals(1, it.size, "Expected exactly one timer in: \"$this\", got: $it")
+    }.first()
+
+    // -- SIMPLE
+
+    @Test fun intMinutes() = assertEquals("(timer://900)", "15 min kochen".singleUri())
+
+    @Test fun decimalCommaMinutes() = assertEquals("(timer://150)", "2,5 Min rühren".singleUri())
+
+    @Test fun decimalDotMinutes() = assertEquals("(timer://150)", "2.5 min warten".singleUri())
+
+    @Test fun germanMinuteFullWord() = assertEquals("(timer://1800)", "30 Minuten".singleUri())
+
+    @Test fun germanDiminutiveMinuetchen() = assertEquals("(timer://120)", "2 Minütchen".singleUri())
+
+    @Test fun hoursOnlyGerman() = assertEquals("(timer://7200)", "2 Stunden".singleUri())
+
+    @Test fun hoursOnlyHrs() = assertEquals("(timer://7200)", "2 hrs".singleUri())
+
+    @Test fun hoursOnlyH() = assertEquals("(timer://3600)", "1h".singleUri())
+
+    @Test fun decimalHours() = assertEquals("(timer://5400)", "1,5h".singleUri())
+
+    @Test fun germanStd() = assertEquals("(timer://3600)", "1 Std.".singleUri())
+
+    @Test fun germanDiminutiveStuendchen() = assertEquals("(timer://3600)", "1 Stündchen".singleUri())
+
+    @Test fun intSeconds() = assertEquals("(timer://45)", "45 sec".singleUri())
+
+    @Test fun fullWordSeconds() = assertEquals("(timer://30)", "30 seconds".singleUri())
+
+    @Test fun germanSekWithDot() = assertEquals("(timer://45)", "45 Sek. stehen lassen".singleUri())
+
+    @Test fun germanDiminutiveSekuendchen() = assertEquals("(timer://30)", "30 Sekündchen".singleUri())
+
+    @Test fun decimalSeconds() = assertEquals("(timer://2)", "2.5 s".singleUri())
+
+    // -- Combos
+
+    @Test fun hoursAndMinutes() = assertEquals("(timer://5400)", "1 Stunde 30 Minuten".singleUri())
+
+    @Test fun hoursUndMinutes() = assertEquals("(timer://5400)", "1 Stunde und 30 Minuten".singleUri())
+
+    @Test fun hoursAndMinutesEnglish() = assertEquals("(timer://5400)", "1 hour and 30 minutes".singleUri())
+
+    @Test fun compactHMin() = assertEquals("(timer://5400)", "1h 30min".singleUri())
+
+    @Test fun stdDotMinDot() = assertEquals("(timer://4800)", "1 Std. 20 Min.".singleUri())
+
+    // -- ranges
+
+    @Test fun dashRangeMinutes() = assertEquals("(timer-range://600/900)", "10-15 min".singleUri())
+
+    @Test fun spacedDashRangeMinutes() = assertEquals("(timer-range://600/900)", "10 - 15 min".singleUri())
+
+    @Test fun wordRangeBis() = assertEquals("(timer-range://600/900)", "10 bis 15 Minuten".singleUri())
+
+    @Test fun wordRangeTo() = assertEquals("(timer-range://600/900)", "10 to 15 min".singleUri())
+
+    @Test fun dashRangeSeconds() = assertEquals("(timer-range://15/23)", "15-23.5 sec".singleUri())
+
+    @Test fun dashRangeHours() = assertEquals("(timer-range://3600/7200)", "1-2 Stunden".singleUri())
+
+    @Test fun decimalCommaRangeMinutes() = assertEquals("(timer-range://90/150)", "1,5-2,5 min".singleUri())
+
+    @Test fun decimalMixedCommaRangeMinutesWithDot() = assertEquals("(timer-range://90/150)", "1,5-2.5 min.".singleUri())
+
+    @Test fun qualifierMaximal() =
+        assertEquals("(timer-range://600/900)", "10 bis maximal 15 Minuten".singleUri())
+
+    @Test fun qualifierMindestens() =
+        assertEquals("(timer-range://600/900)", "10 bis mindestens 15 Minuten".singleUri())
+
+    @Test fun qualifierEtwa() =
+        assertEquals("(timer-range://600/900)", "10 bis etwa 15 Minuten".singleUri())
+
+    @Test fun qualifierAbout() =
+        assertEquals("(timer-range://600/900)", "10 to about 15 min".singleUri())
+
+    @Test fun qualifierAtMost() =
+        assertEquals("(timer-range://600/900)", "10 to at most 15 min".singleUri())
+
+    @Test fun qualifierUpTo() =
+        assertEquals("(timer-range://600/900)", "10 to up to 15 min".singleUri())
+
+    @Test fun qualifierUpToDecimal() =
+        assertEquals("(timer-range://600/930)", "10 to up to 15.5 min".singleUri())
+
+    @Test fun crossUnitRangeSecondsToMinutes() =
+        assertEquals("(timer-range://15/2700)", "15 Sekunden bis 45 Minuten nochmal".singleUri())
+
+    @Test fun sameUnitRangeWithDecimalHoursAndQualifier() =
+        assertEquals("(timer-range://1800/8280)", "0.5 bis maximal 2,3h kochen lassen".singleUri())
+
+    @Test fun crossUnitAndSingleInOneSentence() {
+        val uris = "0.5 bis maximal 2,3h kochen lassen und dann 15 Sekunden bis 45 Minuten nochmal".timerUris()
+        assertEquals(2, uris.size)
+        assertTrue("(timer-range://1800/8280)" in uris)
+        assertTrue("(timer-range://15/2700)" in uris)
+    }
+
+    // -- multiple
+
+    @Test fun multipleTimers() {
+        val uris = "15 min kochen dann 30 sec warten".timerUris()
+        assertEquals(2, uris.size)
+        assertTrue("(timer://900)" in uris)
+        assertTrue("(timer://30)" in uris)
+    }
+
+    // -- no false positive
+
+    @Test fun noMatchPlainText() = assertTrue("Guten Morgen, schöner Tag!".timerUris().isEmpty())
+
+    @Test fun noMatchNumberAlone() = assertTrue("Nimm 5 Äpfel".timerUris().isEmpty())
+
+    @Test fun noMatchNumberAloneMisleadingSeconds() = assertTrue("Die 2 Sekundarstufe :D".timerUris().isEmpty())
+}


### PR DESCRIPTION
Hello again saw issue https://github.com/aimok04/kitshn/issues/306 and resolved it.

The timer detection is now seperate in time namespace in which i would want most time formatting and time functionality in the future.

It is quite a complex regex but you can see what it all covers now. I have tested it with this step text which is completly crazy but works:

Zuerst 15 min kochen, dann 2,5 Min rühren oder 2.5 min Danach 15-23.5 sec abkühlen, oder 10 bis 15 Minuten ruhen lassen.
  Alternativ 10 to 15 min reichen auch. 45 Sek. stehen lassen.
  Für 1 Stunde 30 Minuten im Ofen, oder 1 Stunde und 30 Minuten geduldig warten.
  Kurzform: 1h 30min oder 1,5h. Auf 2 Stunden oder 2 hrs aufgießen.
  Zum Schluss 1 Std. 20 Min. backen, dann 30 seconds abkühlen. 23 Stündchen schmoren 1.5Minütchen abkühlen 1,5  Sekündchen richen und dann 10 minuten abschmecken

0.5 bis maximal 2,3h kochen lassen und dann 15 Sekunden bis 45 Minuten nochmal

The timer range selector now does better handling of multiple unit classes although there are some kinks left but its still an improvement