### PR TITLE
feat: improve timer detector with dashes, fractions and multi localize

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -255,3 +255,147 @@ buildConfig {
 tasks.withType<CompileArtProfileTask> {
     enabled = false
 }
+
+abstract class GenerateLocalizedResources : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val resourceDirectory: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val stringNames: ListProperty<String>
+
+    @get:Input
+    abstract val stringArrayNames: ListProperty<String>
+
+    private fun languageOf(directoryName: String): String? {
+        if(directoryName == "values") return "en"
+        val qualifiers = directoryName.removePrefix("values-").takeIf { it != directoryName }
+            ?: return null
+        val language = if(qualifiers.startsWith("b+")) {
+            qualifiers.removePrefix("b+").substringBefore('+')
+        } else {
+            qualifiers.substringBefore('-')
+        }
+        return language.lowercase().takeIf { it.isNotBlank() }
+    }
+
+    private fun String.matchesAny(patterns: List<String>) = patterns.any { pattern ->
+        if(pattern.endsWith("*")) startsWith(pattern.dropLast(1)) else this == pattern
+    }
+
+    private fun String.escapeKotlin() = replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("$", "\\$")
+
+    private fun org.w3c.dom.Node.childElements(tag: String): List<org.w3c.dom.Element> {
+        val nodes = when(this) {
+            is org.w3c.dom.Document -> getElementsByTagName(tag)
+            is org.w3c.dom.Element -> getElementsByTagName(tag)
+            else -> return emptyList()
+        }
+        return (0 until nodes.length).map { nodes.item(it) as org.w3c.dom.Element }
+    }
+
+    private fun renderMap(entries: Map<String, Map<String, String>>): String {
+        if(entries.isEmpty()) return "emptyMap()"
+        return entries.entries.joinToString(",\n", "mapOf(\n", "\n)") { (name, byLanguage) ->
+            val languages = byLanguage.entries.joinToString(",\n") { (language, value) ->
+                """        "$language" to $value"""
+            }
+            "    \"$name\" to mapOf(\n$languages\n    )"
+        }
+    }
+
+    @TaskAction
+    fun generate() {
+        val builder = javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder()
+
+        val strings = sortedMapOf<String, MutableMap<String, String>>()
+        val arrays = sortedMapOf<String, MutableMap<String, MutableList<String>>>()
+
+        resourceDirectory.get().asFile.listFiles()
+            .orEmpty()
+            .filter { it.isDirectory }
+            .sortedBy { it.name }
+            .forEach { directory ->
+                val language = languageOf(directory.name) ?: return@forEach
+                val file = directory.resolve("strings.xml").takeIf { it.isFile } ?: return@forEach
+                val document = builder.parse(file)
+
+                document.childElements("string")
+                    .filter { it.getAttribute("name").matchesAny(stringNames.get()) }
+                    .forEach { element ->
+                        val value = element.textContent.trim().takeIf(String::isNotEmpty)
+                            ?: return@forEach
+                        // Locale variants of the same language (values-pt-rBR, values-pt) are
+                        // merged
+                        strings.getOrPut(element.getAttribute("name")) { sortedMapOf() }
+                            .putIfAbsent(language, value)
+                    }
+
+                document.childElements("string-array")
+                    .filter { it.getAttribute("name").matchesAny(stringArrayNames.get()) }
+                    .forEach { element ->
+                        val items = element.childElements("item")
+                            .map { it.textContent.trim() }
+                            .filter { it.isNotEmpty() }
+                        if(items.isEmpty()) return@forEach
+
+                        arrays.getOrPut(element.getAttribute("name")) { sortedMapOf() }
+                            .getOrPut(language) { mutableListOf() }
+                            .addAll(items)
+                    }
+            }
+
+        val stringEntries = renderMap(
+            strings.mapValues { (_, byLanguage) ->
+                byLanguage.mapValues { (_, value) -> "\"${value.escapeKotlin()}\"" }
+            }
+        )
+
+        val arrayEntries = renderMap(
+            arrays.mapValues { (_, byLanguage) ->
+                byLanguage.mapValues { (_, items) ->
+                    items.distinct().joinToString(", ", "listOf(", ")") {
+                        "\"${it.escapeKotlin()}\""
+                    }
+                }
+            }
+        )
+
+        val output = outputDirectory.get().asFile
+            .resolve(packageName.get().replace('.', '/'))
+        output.mkdirs()
+        output.resolve("MultiLocalizeGenerated.kt").writeText(
+            """
+            |// Generated by :shared:generateLocalizedResources -- do not edit.
+            |// Source: shared/src/commonMain/composeResources/values*/strings.xml
+            |package ${packageName.get()}
+            |
+            |internal val LOCALIZED_STRINGS: Map<String, Map<String, String>> = $stringEntries
+            |
+            |internal val LOCALIZED_STRING_ARRAYS: Map<String, Map<String, List<String>>> = $arrayEntries
+            |
+            """.trimMargin()
+        )
+    }
+}
+
+val generateLocalizedResources =
+    tasks.register<GenerateLocalizedResources>("generateLocalizedResources") {
+        description = "Generate locale maps for multi language sections of the App"
+        resourceDirectory.set(layout.projectDirectory.dir("src/commonMain/composeResources"))
+        outputDirectory.set(layout.buildDirectory.dir("generated/localizedResources/kotlin"))
+        packageName.set("de.kitshn.language")
+        stringNames.set(emptyList<String>()) // resources to include everywhere
+        stringArrayNames.set(listOf("timer_detection_*"))
+    }
+
+kotlin.sourceSets.commonMain { kotlin.srcDir(generateLocalizedResources) }

--- a/shared/src/androidMain/kotlin/de/kitshn/language/MultiLocalize.android.kt
+++ b/shared/src/androidMain/kotlin/de/kitshn/language/MultiLocalize.android.kt
@@ -1,0 +1,14 @@
+package de.kitshn.language
+
+import android.content.res.Resources
+import android.os.LocaleList
+
+actual fun preferredLanguageTags(): List<String> {
+    val locales = buildList {
+        // The app's adjusted list first, then the full system list from device settings.
+        listOf(LocaleList.getDefault(), Resources.getSystem().configuration.locales)
+            .forEach { list -> repeat(list.size()) { add(list[it].language) } }
+    }
+
+    return locales.normalizeLanguageTags()
+}

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -391,6 +391,39 @@
     <string name="common_select_users_for_sharing">Wähle Nutzer zum teilen</string>
     <string name="common_select_users_for_sharing_empty">Wähle Nutzer, mit denen du diesen Eintrag teilen möchtest.</string>
     <string name="search_users">Nutzer suchen</string>
+    <string-array name="timer_detection_number_definitions">
+        <item>1=eine</item>
+        <item>1=ein</item>
+        <item>2=zwei</item>
+        <item>3=drei</item>
+        <item>4=vier</item>
+        <item>5=fünf</item>
+        <item>6=sechs</item>
+        <item>7=sieben</item>
+        <item>8=acht</item>
+        <item>9=neun</item>
+        <item>10=zehn</item>
+        <item>11=elf</item>
+        <item>12=zwölf</item>
+        <item>15=fünfzehn</item>
+        <item>20=zwanzig</item>
+        <item>30=dreißig</item>
+        <item>30=dreissig</item>
+        <item>45=fünfundvierzig</item>
+        <item>60=sechzig</item>
+        <item>90=neunzig</item>
+        <item>0.25=viertel</item>
+        <item>0.25=eine viertel</item>
+        <item>0.5=halbe</item>
+        <item>0.5=halben</item>
+        <item>0.5=eine halbe</item>
+        <item>0.75=dreiviertel</item>
+        <item>0.75=eine dreiviertel</item>
+        <item>1.5=anderthalb</item>
+        <item>1.5=eineinhalb</item>
+        <item>2.5=zweieinhalb</item>
+    </string-array>
+
     <string-array name="timer_detection_hour_definitions">
         <item>stündchen</item>
         <item>stunden</item>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -400,6 +400,7 @@
     </string-array>
     <string-array name="timer_detection_and_definitions">
         <item>und</item>
+        <item>&amp;</item>
     </string-array>
     <string-array name="timer_detection_minute_definitions">
         <item>minütchen</item>
@@ -418,6 +419,7 @@
     </string-array>
     <string-array name="timer_detection_to_definitions">
         <item>bis</item>
+        <item>oder</item>
     </string-array>
 
     <string-array name="timer_detection_range_qualifier_definitions">
@@ -427,6 +429,11 @@
         <item>ungefähr</item>
         <item>etwa</item>
         <item>ca.</item>
+        <item>circa</item>
+        <item>zirka</item>
+        <item>max.</item>
+        <item>knapp</item>
+        <item>rund</item>
     </string-array>
     <string name="error_outdated_v1_instance">Diese Version von kitshn unterstützt Tandoor v1 nicht. Bitte aktualisiere entweder auf Tandoor v2 oder installiere eine ältere Version von kitshn.</string>
     <string name="kofi_support_description">Du kannst die Entwicklung von kitshn auf Ko-Fi unterstützen</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -473,6 +473,35 @@
 
 
 
+    <string-array name="timer_detection_number_definitions">
+        <item>1=one</item>
+        <item>2=two</item>
+        <item>3=three</item>
+        <item>4=four</item>
+        <item>5=five</item>
+        <item>6=six</item>
+        <item>7=seven</item>
+        <item>8=eight</item>
+        <item>9=nine</item>
+        <item>10=ten</item>
+        <item>11=eleven</item>
+        <item>12=twelve</item>
+        <item>15=fifteen</item>
+        <item>20=twenty</item>
+        <item>30=thirty</item>
+        <item>45=forty-five</item>
+        <item>45=forty five</item>
+        <item>60=sixty</item>
+        <item>90=ninety</item>
+        <item>0.25=quarter</item>
+        <item>0.25=a quarter</item>
+        <item>0.5=half</item>
+        <item>0.5=a half</item>
+        <item>0.5=half an</item>
+        <item>0.75=three quarters</item>
+        <item>1.5=one and a half</item>
+    </string-array>
+
     <string-array name="timer_detection_hour_definitions">
         <item>hours</item>
         <item>hour</item>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -411,6 +411,8 @@
     <string name="settings_section_behavior_ios_install_timer_shortcut_label">Install iOS timer shortcut</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_description">Prevent the screen from sleeping while viewing recipe details, just like in Cooking Mode</string>
     <string name="settings_section_behavior_keep_screen_on_in_recipe_details_label">Keep screen on in recipe overview</string>
+    <string name="settings_section_behavior_timer_detection_all_languages_description">Recognize timers written in any language installed on this device, else only the kitshn language + English are recognized</string>
+    <string name="settings_section_behavior_timer_detection_all_languages_label">Detect timers in all installed languages</string>
     <string name="settings_section_behavior_shopping_item_double_click_check_label">Double-click to check shopping items</string>
     <string name="settings_section_behavior_shopping_item_double_click_check_description">Quickly mark shopping items as completed by double-clicking</string>
     <string name="settings_section_behavior_label">Behavior</string>
@@ -478,6 +480,7 @@
 
     <string-array name="timer_detection_and_definitions">
         <item>and</item>
+        <item>&amp;</item>
     </string-array>
 
     <string-array name="timer_detection_minute_definitions">
@@ -496,6 +499,9 @@
 
     <string-array name="timer_detection_to_definitions">
         <item>to</item>
+        <item>or</item>
+        <item>until</item>
+        <item>till</item>
     </string-array>
 
     <string-array name="timer_detection_range_qualifier_definitions">

--- a/shared/src/commonMain/kotlin/de/kitshn/Settings.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/Settings.kt
@@ -48,6 +48,8 @@ const val KEY_SETTINGS_BEHAVIOR_PROPERTIES_SHOW_FRACTIONAL_VALUES =
     "behavior_properties_show_fractional_values"
 const val KEY_SETTINGS_BEHAVIOR_KEEP_SCREEN_ON_IN_RECIPE_DETAILS =
     "behavior_keep_screen_on_in_recipe_details"
+const val KEY_SETTINGS_BEHAVIOR_TIMER_DETECTION_ALL_LANGUAGES =
+    "behavior_timer_detection_all_languages"
 const val KEY_SETTINGS_BEHAVIOR_HIDE_FUNDING_BANNER_UNTIL =
     "behavior_hide_funding_banner_until"
 
@@ -215,6 +217,12 @@ class SettingsViewModel : ViewModel() {
 
     fun setPropertiesShowFractionalValues(show: Boolean) =
         obs.putBoolean(KEY_SETTINGS_BEHAVIOR_PROPERTIES_SHOW_FRACTIONAL_VALUES, show)
+
+    val getTimerDetectionAllLanguages: Flow<Boolean> =
+        obs.getBooleanFlow(KEY_SETTINGS_BEHAVIOR_TIMER_DETECTION_ALL_LANGUAGES, true)
+
+    fun setTimerDetectionAllLanguages(enable: Boolean) =
+        obs.putBoolean(KEY_SETTINGS_BEHAVIOR_TIMER_DETECTION_ALL_LANGUAGES, enable)
 
     val getKeepScreenOnInRecipeDetails: Flow<Boolean> =
         obs.getBooleanFlow(KEY_SETTINGS_BEHAVIOR_KEEP_SCREEN_ON_IN_RECIPE_DETAILS, false)

--- a/shared/src/commonMain/kotlin/de/kitshn/language/MultiLocalize.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/language/MultiLocalize.kt
@@ -1,0 +1,39 @@
+package de.kitshn.language
+
+expect fun preferredLanguageTags(): List<String>
+
+internal fun List<String>.normalizeLanguageTags(): List<String> = asSequence()
+    .map { it.trim().replace('_', '-').substringBefore('-').lowercase() }
+    .filter { it.isNotBlank() && it != "c" && it != "posix" }
+    .distinct()
+    .toList()
+
+fun localizedString(name: String): Map<String, String> = LOCALIZED_STRINGS[name].orEmpty()
+
+fun localizedStringArray(name: String): Map<String, List<String>> =
+    LOCALIZED_STRING_ARRAYS[name].orEmpty()
+
+fun multiLocalizeLanguages(
+    activeLanguage: String,
+    allInstalledLanguages: Boolean,
+    alwaysIncluded: List<String> = emptyList()
+): List<String> = buildList {
+    add(activeLanguage)
+    if(allInstalledLanguages) addAll(preferredLanguageTags())
+    addAll(alwaysIncluded)
+}.normalizeLanguageTags()
+
+fun multiLocalize(
+    names: List<String>,
+    activeLanguage: String,
+    allInstalledLanguages: Boolean,
+    alwaysIncluded: List<String> = emptyList()
+): List<Map<String, List<String>>> {
+    val arrays = names.associateWith { localizedStringArray(it) }
+
+    return multiLocalizeLanguages(activeLanguage, allInstalledLanguages, alwaysIncluded)
+        .mapNotNull { language ->
+            names.associateWith { name -> arrays.getValue(name)[language].orEmpty() }
+                .takeIf { defs -> defs.values.any(List<String>::isNotEmpty) }
+        }
+}

--- a/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetection.kt
@@ -8,7 +8,8 @@ data class TimerDetectionDefs(
     val minuteDefs: Set<String>,
     val secondDefs: Set<String>,
     val rangeDefs: Set<String>,
-    val rangeQualifierDefs: Set<String> = emptySet()
+    val rangeQualifierDefs: Set<String> = emptySet(),
+    val numberDefs: Map<String, Double> = emptyMap()
 )
 
 /** combine languages */
@@ -18,7 +19,8 @@ operator fun TimerDetectionDefs.plus(other: TimerDetectionDefs) = TimerDetection
     minuteDefs = minuteDefs + other.minuteDefs,
     secondDefs = secondDefs + other.secondDefs,
     rangeDefs = rangeDefs + other.rangeDefs,
-    rangeQualifierDefs = rangeQualifierDefs + other.rangeQualifierDefs
+    rangeQualifierDefs = rangeQualifierDefs + other.rangeQualifierDefs,
+    numberDefs = numberDefs + other.numberDefs
 )
 
 fun Iterable<TimerDetectionDefs>.mergeDefs(): TimerDetectionDefs =
@@ -55,9 +57,11 @@ private val COMMON_FRACTIONS = mapOf(
 
 private val COMMON_FRACTIONS_CLASS = COMMON_FRACTIONS.keys.joinToString("", "[", "]")
 
-private fun parseNumber(value: String): Double {
+private fun parseNumber(value: String, numberDefs: Map<String, Double>): Double {
     val text = value.trim().replace(',', '.')
     if(text.isEmpty()) return 0.0
+
+    numberDefs[text.lowercase().replace(WHITESPACE, " ")]?.let { return it }
 
     COMMON_FRACTIONS[text.last()]?.let { fraction ->
         return (text.dropLast(1).trim().toDoubleOrNull() ?: 0.0) + fraction
@@ -74,12 +78,17 @@ private fun parseNumber(value: String): Double {
     return whole + numerator / denominator
 }
 
-private fun parseToSeconds(value: String, multiplier: Double): Int =
-    (parseNumber(value) * multiplier).roundToInt()
+private fun parseToSeconds(defs: TimerDetectionDefs, value: String, multiplier: Double): Int =
+    (parseNumber(value, defs.numberDefs) * multiplier).roundToInt()
 
-private fun Set<String>.toRegexAlt(): String =
+private val WHITESPACE = Regex("""\s+""")
+
+/** Literal whitespace has to survive the pattern's COMMENTS mode. */
+private fun Iterable<String>.toRegexAlt(): String =
     sortedByDescending(String::length)
-        .joinToString("|") { Regex.escape(it) }
+        .joinToString("|") { definition ->
+            definition.split(WHITESPACE).joinToString("""\s+""") { Regex.escape(it) }
+        }
 
 fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
 
@@ -87,6 +96,10 @@ fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
     val minutes = defs.minuteDefs.toRegexAlt()
     val seconds = defs.secondDefs.toRegexAlt()
     val andWords = defs.andDefs.toRegexAlt()
+    val numberWords = defs.numberDefs.keys
+        .takeIf(Set<String>::isNotEmpty)
+        ?.let { "|${it.toRegexAlt()}" }
+        .orEmpty()
     // Mixed fractions ("2 1/2", "2 1/2") come first so the whole figure wins over its parts.
     val number = """(?:
         [0-9]+\s+[0-9]+/[0-9]+
@@ -94,6 +107,7 @@ fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
         |[0-9]+/[0-9]+
         |$COMMON_FRACTIONS_CLASS
         |[0-9]+(?:[.,][0-9]+)?
+        $numberWords
     )"""
     val unit = "$hours|$minutes|$seconds"
 
@@ -162,27 +176,27 @@ fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
 
         when {
             named("crossFrom").isNotBlank() -> range(
-                parseToSeconds(named("crossFrom"), unitMultiplier(named("crossFromUnit"))),
-                parseToSeconds(named("crossTo"), unitMultiplier(named("crossToUnit")))
+                parseToSeconds(defs, named("crossFrom"), unitMultiplier(named("crossFromUnit"))),
+                parseToSeconds(defs, named("crossTo"), unitMultiplier(named("crossToUnit")))
             )
 
             named("sameFrom").isNotBlank() -> {
                 val mult = unitMultiplier(named("sameUnit"))
                 range(
-                    parseToSeconds(named("sameFrom"), mult),
-                    parseToSeconds(named("sameTo"), mult)
+                    parseToSeconds(defs, named("sameFrom"), mult),
+                    parseToSeconds(defs, named("sameTo"), mult)
                 )
             }
 
             named("hoursOnly").isNotBlank() ->
-                timer(parseToSeconds(named("hoursOnly"), 3600.0))
+                timer(parseToSeconds(defs, named("hoursOnly"), 3600.0))
 
             named("secondsOnly").isNotBlank() ->
-                timer(parseToSeconds(named("secondsOnly"), 1.0))
+                timer(parseToSeconds(defs, named("secondsOnly"), 1.0))
 
             else -> timer(
-                parseToSeconds(named("comboHours").ifBlank { "0" }, 3600.0) +
-                        parseToSeconds(named("comboMinutes").ifBlank { "0" }, 60.0)
+                parseToSeconds(defs, named("comboHours").ifBlank { "0" }, 3600.0) +
+                        parseToSeconds(defs, named("comboMinutes").ifBlank { "0" }, 60.0)
             )
         }
     }

--- a/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetection.kt
@@ -1,5 +1,7 @@
 package de.kitshn.time
 
+import kotlin.math.roundToInt
+
 data class TimerDetectionDefs(
     val hourDefs: Set<String>,
     val andDefs: Set<String>,
@@ -9,8 +11,71 @@ data class TimerDetectionDefs(
     val rangeQualifierDefs: Set<String> = emptySet()
 )
 
+/** combine languages */
+operator fun TimerDetectionDefs.plus(other: TimerDetectionDefs) = TimerDetectionDefs(
+    hourDefs = hourDefs + other.hourDefs,
+    andDefs = andDefs + other.andDefs,
+    minuteDefs = minuteDefs + other.minuteDefs,
+    secondDefs = secondDefs + other.secondDefs,
+    rangeDefs = rangeDefs + other.rangeDefs,
+    rangeQualifierDefs = rangeQualifierDefs + other.rangeQualifierDefs
+)
+
+fun Iterable<TimerDetectionDefs>.mergeDefs(): TimerDetectionDefs =
+    fold(EMPTY_TIMER_DETECTION_DEFS) { acc, defs -> acc + defs }
+
+val EMPTY_TIMER_DETECTION_DEFS = TimerDetectionDefs(
+    hourDefs = emptySet(),
+    andDefs = emptySet(),
+    minuteDefs = emptySet(),
+    secondDefs = emptySet(),
+    rangeDefs = emptySet()
+)
+
+val UNIVERSAL_TIMER_DETECTION_DEFS = TimerDetectionDefs(
+    hourDefs = setOf("h", "hr", "hrs"),
+    andDefs = emptySet(),
+    minuteDefs = setOf("min", "mins"),
+    secondDefs = setOf("s", "sec", "secs"),
+    rangeDefs = emptySet()
+)
+
+/** We must handle whitespaces differently in ideographic languages */
+private fun Char.isIdeographic(): Boolean = this in '\u3040'..'\u30FF' ||
+        this in '\u3400'..'\u4DBF' || this in '\u4E00'..'\u9FFF' || this in '\uF900'..'\uFAFF'
+
+private val COMMON_FRACTIONS = mapOf(
+    '¼' to 1.0 / 4, '½' to 1.0 / 2, '¾' to 3.0 / 4,
+    '⅐' to 1.0 / 7, '⅑' to 1.0 / 9, '⅒' to 1.0 / 10,
+    '⅓' to 1.0 / 3, '⅔' to 2.0 / 3,
+    '⅕' to 1.0 / 5, '⅖' to 2.0 / 5, '⅗' to 3.0 / 5, '⅘' to 4.0 / 5,
+    '⅙' to 1.0 / 6, '⅚' to 5.0 / 6,
+    '⅛' to 1.0 / 8, '⅜' to 3.0 / 8, '⅝' to 5.0 / 8, '⅞' to 7.0 / 8
+)
+
+private val COMMON_FRACTIONS_CLASS = COMMON_FRACTIONS.keys.joinToString("", "[", "]")
+
+private fun parseNumber(value: String): Double {
+    val text = value.trim().replace(',', '.')
+    if(text.isEmpty()) return 0.0
+
+    COMMON_FRACTIONS[text.last()]?.let { fraction ->
+        return (text.dropLast(1).trim().toDoubleOrNull() ?: 0.0) + fraction
+    }
+
+    val slash = text.indexOf('/')
+    if(slash == -1) return text.toDoubleOrNull() ?: 0.0
+
+    val denominator = text.substring(slash + 1).toDoubleOrNull()?.takeIf { it != 0.0 } ?: return 0.0
+    val head = text.substring(0, slash).trim()
+    val numerator = head.substringAfterLast(' ').toDoubleOrNull() ?: 0.0
+    val whole = head.substringBeforeLast(' ', "").trim().toDoubleOrNull() ?: 0.0
+
+    return whole + numerator / denominator
+}
+
 private fun parseToSeconds(value: String, multiplier: Double): Int =
-    ((value.replace(',', '.').toDoubleOrNull() ?: 0.0) * multiplier).toInt()
+    (parseNumber(value) * multiplier).roundToInt()
 
 private fun Set<String>.toRegexAlt(): String =
     sortedByDescending(String::length)
@@ -22,7 +87,14 @@ fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
     val minutes = defs.minuteDefs.toRegexAlt()
     val seconds = defs.secondDefs.toRegexAlt()
     val andWords = defs.andDefs.toRegexAlt()
-    val number = """[0-9]+(?:[.,][0-9]+)?"""
+    // Mixed fractions ("2 1/2", "2 1/2") come first so the whole figure wins over its parts.
+    val number = """(?:
+        [0-9]+\s+[0-9]+/[0-9]+
+        |[0-9]+\s*$COMMON_FRACTIONS_CLASS
+        |[0-9]+/[0-9]+
+        |$COMMON_FRACTIONS_CLASS
+        |[0-9]+(?:[.,][0-9]+)?
+    )"""
     val unit = "$hours|$minutes|$seconds"
 
     val qualifier = defs.rangeQualifierDefs
@@ -31,11 +103,15 @@ fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
         ?.let { """(?:(?:$it)\s+)?""" }
         .orEmpty()
 
+    // Every dash like separator
+    val dash =
+        """[-\u058A\u05BE\u1400\u1806\u2010-\u2015\u2053\u2212\u2E17\u2E1A\u2E3A\u2E3B\u2E40\u2E5D\u301C\u3030\u30A0\uFE31\uFE32\uFE58\uFE63\uFF0D]"""
+
     val rangeSep = if (defs.rangeDefs.isNotEmpty()) {
         val rangeWords = defs.rangeDefs.toRegexAlt()
-        """(?:\s*-\s*|\s+(?:$rangeWords)\s+$qualifier)"""
+        """(?:\s*$dash\s*|\s+(?:$rangeWords)\s+$qualifier)"""
     } else {
-        """\s*-\s*"""
+        """\s*$dash\s*"""
     }
 
     val hourRegex = Regex("^($hours)$", RegexOption.IGNORE_CASE)
@@ -74,6 +150,12 @@ fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
     )
 
     return markdown.replace(pattern) { m ->
+        val next = markdown.getOrNull(m.range.last + 1)
+        val unitEnd = m.value.last()
+        if (next != null && (next.isLetter() || next.isDigit()) &&
+            !next.isIdeographic() && !unitEnd.isIdeographic()
+        ) return@replace m.value
+
         fun named(n: String) = m.groups[n]?.value.orEmpty()
         fun timer(s: Int) = "[**⏲ ${m.value}**](timer://$s)"
         fun range(from: Int, to: Int) = "[**⏲ ${m.value}**](timer-range://$from/$to)"
@@ -83,17 +165,24 @@ fun detectTimers(markdown: String, defs: TimerDetectionDefs): String {
                 parseToSeconds(named("crossFrom"), unitMultiplier(named("crossFromUnit"))),
                 parseToSeconds(named("crossTo"), unitMultiplier(named("crossToUnit")))
             )
+
             named("sameFrom").isNotBlank() -> {
                 val mult = unitMultiplier(named("sameUnit"))
-                range(parseToSeconds(named("sameFrom"), mult), parseToSeconds(named("sameTo"), mult))
+                range(
+                    parseToSeconds(named("sameFrom"), mult),
+                    parseToSeconds(named("sameTo"), mult)
+                )
             }
+
             named("hoursOnly").isNotBlank() ->
                 timer(parseToSeconds(named("hoursOnly"), 3600.0))
+
             named("secondsOnly").isNotBlank() ->
                 timer(parseToSeconds(named("secondsOnly"), 1.0))
+
             else -> timer(
                 parseToSeconds(named("comboHours").ifBlank { "0" }, 3600.0) +
-                    parseToSeconds(named("comboMinutes").ifBlank { "0" }, 60.0)
+                        parseToSeconds(named("comboMinutes").ifBlank { "0" }, 60.0)
             )
         }
     }

--- a/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetectionVocabulary.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetectionVocabulary.kt
@@ -1,0 +1,40 @@
+package de.kitshn.time
+
+import de.kitshn.language.multiLocalize
+
+private const val HOUR_DEFINITIONS = "timer_detection_hour_definitions"
+private const val AND_DEFINITIONS = "timer_detection_and_definitions"
+private const val MINUTE_DEFINITIONS = "timer_detection_minute_definitions"
+private const val SECOND_DEFINITIONS = "timer_detection_second_definitions"
+private const val TO_DEFINITIONS = "timer_detection_to_definitions"
+private const val RANGE_QUALIFIER_DEFINITIONS = "timer_detection_range_qualifier_definitions"
+
+private val TIMER_DETECTION_DEFINITIONS = listOf(
+    HOUR_DEFINITIONS,
+    AND_DEFINITIONS,
+    MINUTE_DEFINITIONS,
+    SECOND_DEFINITIONS,
+    TO_DEFINITIONS,
+    RANGE_QUALIFIER_DEFINITIONS
+)
+
+private fun Map<String, List<String>>.wordsOf(name: String) = this[name].orEmpty().toSet()
+
+fun timerDetectionDefs(
+    activeLanguage: String,
+    allInstalledLanguages: Boolean
+): TimerDetectionDefs = (listOf(UNIVERSAL_TIMER_DETECTION_DEFS) + multiLocalize(
+    names = TIMER_DETECTION_DEFINITIONS,
+    activeLanguage = activeLanguage,
+    allInstalledLanguages = allInstalledLanguages,
+    alwaysIncluded = listOf("en")
+).map { definitions ->
+    TimerDetectionDefs(
+        hourDefs = definitions.wordsOf(HOUR_DEFINITIONS),
+        andDefs = definitions.wordsOf(AND_DEFINITIONS),
+        minuteDefs = definitions.wordsOf(MINUTE_DEFINITIONS),
+        secondDefs = definitions.wordsOf(SECOND_DEFINITIONS),
+        rangeDefs = definitions.wordsOf(TO_DEFINITIONS),
+        rangeQualifierDefs = definitions.wordsOf(RANGE_QUALIFIER_DEFINITIONS)
+    )
+}).mergeDefs()

--- a/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetectionVocabulary.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/time/TimerDetectionVocabulary.kt
@@ -8,6 +8,7 @@ private const val MINUTE_DEFINITIONS = "timer_detection_minute_definitions"
 private const val SECOND_DEFINITIONS = "timer_detection_second_definitions"
 private const val TO_DEFINITIONS = "timer_detection_to_definitions"
 private const val RANGE_QUALIFIER_DEFINITIONS = "timer_detection_range_qualifier_definitions"
+private const val NUMBER_DEFINITIONS = "timer_detection_number_definitions"
 
 private val TIMER_DETECTION_DEFINITIONS = listOf(
     HOUR_DEFINITIONS,
@@ -15,10 +16,20 @@ private val TIMER_DETECTION_DEFINITIONS = listOf(
     MINUTE_DEFINITIONS,
     SECOND_DEFINITIONS,
     TO_DEFINITIONS,
-    RANGE_QUALIFIER_DEFINITIONS
+    RANGE_QUALIFIER_DEFINITIONS,
+    NUMBER_DEFINITIONS
 )
 
 private fun Map<String, List<String>>.wordsOf(name: String) = this[name].orEmpty().toSet()
+
+/** Spelled out numbers are defined as `<value>=<word>`, e.g. `0.5=halbe`. */
+private fun Map<String, List<String>>.numbersOf(name: String) = this[name].orEmpty()
+    .mapNotNull { definition ->
+        val value = definition.substringBefore('=').trim().toDoubleOrNull()
+        val word = definition.substringAfter('=', "").trim().lowercase()
+        if(value == null || word.isEmpty()) null else word to value
+    }
+    .toMap()
 
 fun timerDetectionDefs(
     activeLanguage: String,
@@ -35,6 +46,7 @@ fun timerDetectionDefs(
         minuteDefs = definitions.wordsOf(MINUTE_DEFINITIONS),
         secondDefs = definitions.wordsOf(SECOND_DEFINITIONS),
         rangeDefs = definitions.wordsOf(TO_DEFINITIONS),
-        rangeQualifierDefs = definitions.wordsOf(RANGE_QUALIFIER_DEFINITIONS)
+        rangeQualifierDefs = definitions.wordsOf(RANGE_QUALIFIER_DEFINITIONS),
+        numberDefs = definitions.numbersOf(NUMBER_DEFINITIONS)
     )
 }).mergeDefs()

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/component/MarkdownRichTextWithTimerDetection.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/component/MarkdownRichTextWithTimerDetection.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -18,6 +19,7 @@ import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.isSpecified
@@ -25,17 +27,11 @@ import androidx.compose.ui.unit.sp
 import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownTypography
+import de.kitshn.SettingsViewModel
 import de.kitshn.isLaunchTimerHandlerImplemented
-import de.kitshn.time.TimerDetectionDefs
 import de.kitshn.time.detectTimers
-import kitshn.shared.generated.resources.Res
-import kitshn.shared.generated.resources.timer_detection_and_definitions
-import kitshn.shared.generated.resources.timer_detection_hour_definitions
-import kitshn.shared.generated.resources.timer_detection_minute_definitions
-import kitshn.shared.generated.resources.timer_detection_range_qualifier_definitions
-import kitshn.shared.generated.resources.timer_detection_second_definitions
-import kitshn.shared.generated.resources.timer_detection_to_definitions
-import org.jetbrains.compose.resources.getStringArray
+import de.kitshn.time.timerDetectionDefs
+import org.koin.compose.koinInject
 
 class MarkdownUriHandler(
     val onTimerClick: (seconds: Int) -> Unit,
@@ -66,28 +62,17 @@ fun MarkdownRichTextWithTimerDetection(
 ) {
     val uriHandler = LocalUriHandler.current
 
+    val settings = koinInject<SettingsViewModel>()
+    val allLanguages by settings.getTimerDetectionAllLanguages.collectAsState(initial = true)
+    val activeLanguage = Locale.current.language
+
+    val defs = remember(activeLanguage, allLanguages) {
+        timerDetectionDefs(activeLanguage, allLanguages)
+    }
+
     var md by remember { mutableStateOf("") }
-    LaunchedEffect(markdown) {
-        if(isLaunchTimerHandlerImplemented) {
-            val defs = TimerDetectionDefs(
-                hourDefs = mutableSetOf("h", "hr", "hrs", "hour", "hours")
-                    .apply { addAll(getStringArray(Res.array.timer_detection_hour_definitions)) },
-                andDefs = mutableSetOf<String>()
-                    .apply { addAll(getStringArray(Res.array.timer_detection_and_definitions)) },
-                minuteDefs = mutableSetOf("min", "mins", "minute", "minutes")
-                    .apply { addAll(getStringArray(Res.array.timer_detection_minute_definitions)) },
-                secondDefs = mutableSetOf("s", "sec", "secs", "second", "seconds")
-                    .apply { addAll(getStringArray(Res.array.timer_detection_second_definitions)) },
-                rangeDefs = mutableSetOf<String>()
-                    .apply { addAll(getStringArray(Res.array.timer_detection_to_definitions)) },
-                rangeQualifierDefs = mutableSetOf(
-                    "about", "around", "approx", "approximately", "at most", "at least", "up to"
-                ).apply { addAll(getStringArray(Res.array.timer_detection_range_qualifier_definitions)) }
-            )
-            md = detectTimers(markdown, defs)
-        } else {
-            md = markdown
-        }
+    LaunchedEffect(markdown, defs) {
+        md = if(isLaunchTimerHandlerImplemented) detectTimers(markdown, defs) else markdown
     }
 
     val markdownUriHandler = remember {

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsBehavior.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/view/settings/SettingsBehavior.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.rounded.DynamicFeed
 import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.Numbers
 import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material.icons.rounded.Translate
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.ShoppingCartCheckout
 import androidx.compose.material.icons.rounded.VisibilityOff
@@ -41,6 +42,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import de.kitshn.KitshnViewModel
 import de.kitshn.Platforms
+import de.kitshn.isLaunchTimerHandlerImplemented
 import de.kitshn.platformDetails
 import de.kitshn.ui.component.buttons.BackButton
 import de.kitshn.ui.component.settings.SettingsListItemPosition
@@ -61,6 +63,8 @@ import kitshn.shared.generated.resources.settings_section_behavior_ingredients_s
 import kitshn.shared.generated.resources.settings_section_behavior_ingredients_show_fractional_values_label
 import kitshn.shared.generated.resources.settings_section_behavior_keep_screen_on_in_recipe_details_description
 import kitshn.shared.generated.resources.settings_section_behavior_keep_screen_on_in_recipe_details_label
+import kitshn.shared.generated.resources.settings_section_behavior_timer_detection_all_languages_description
+import kitshn.shared.generated.resources.settings_section_behavior_timer_detection_all_languages_label
 import kitshn.shared.generated.resources.settings_section_behavior_label
 import kitshn.shared.generated.resources.settings_section_behavior_promote_tomorrows_meal_plan_description
 import kitshn.shared.generated.resources.settings_section_behavior_promote_tomorrows_meal_plan_label
@@ -119,6 +123,9 @@ fun ViewSettingsBehavior(
 
         val behaviorKeepScreenOnInRecipeDetails =
             p.vm.settings.getKeepScreenOnInRecipeDetails.collectAsState(initial = false)
+
+        val behaviorTimerDetectionAllLanguages =
+            p.vm.settings.getTimerDetectionAllLanguages.collectAsState(initial = true)
 
         val fundingBannerHideUntil =
             p.vm.settings.getFundingBannerHideUntil.collectAsState(initial = -1L)
@@ -298,6 +305,27 @@ fun ViewSettingsBehavior(
                 ) {
                     coroutineScope.launch {
                         p.vm.settings.setKeepScreenOnInRecipeDetails(it)
+                    }
+                }
+            }
+
+            if(isLaunchTimerHandlerImplemented) {
+                item {
+                    Spacer(Modifier.height(16.dp))
+                }
+
+                item {
+                    SettingsSwitchListItem(
+                        position = SettingsListItemPosition.SINGULAR,
+                        label = { Text(stringResource(Res.string.settings_section_behavior_timer_detection_all_languages_label)) },
+                        description = { Text(stringResource(Res.string.settings_section_behavior_timer_detection_all_languages_description)) },
+                        icon = Icons.Rounded.Translate,
+                        contentDescription = stringResource(Res.string.settings_section_behavior_timer_detection_all_languages_label),
+                        checked = behaviorTimerDetectionAllLanguages.value
+                    ) {
+                        coroutineScope.launch {
+                            p.vm.settings.setTimerDetectionAllLanguages(it)
+                        }
                     }
                 }
             }

--- a/shared/src/commonTest/kotlin/de/kitshn/language/MultiLocalizeTest.kt
+++ b/shared/src/commonTest/kotlin/de/kitshn/language/MultiLocalizeTest.kt
@@ -1,0 +1,80 @@
+package de.kitshn.language
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val MINUTES = "timer_detection_minute_definitions"
+private const val TO = "timer_detection_to_definitions"
+
+class MultiLocalizeTest {
+
+    @Test fun languageTagsAreNormalized() = assertEquals(
+        listOf("de", "en", "pt"),
+        listOf("de-DE", "de_AT", "en-US.UTF-8", "", "C", "pt-BR").normalizeLanguageTags()
+    )
+
+    @Test fun activeLanguageComesFirstAndIsNormalized() = assertEquals(
+        listOf("pt", "en"),
+        multiLocalizeLanguages(
+            activeLanguage = "pt_BR",
+            allInstalledLanguages = false,
+            alwaysIncluded = listOf("en")
+        )
+    )
+
+    @Test fun alwaysIncludedDoesNotDuplicateActiveLanguage() = assertEquals(
+        listOf("en"),
+        multiLocalizeLanguages(
+            activeLanguage = "en",
+            allInstalledLanguages = false,
+            alwaysIncluded = listOf("en")
+        )
+    )
+
+    @Test fun installedLanguagesAreAppendedWhenEnabled() {
+        val languages = multiLocalizeLanguages(
+            activeLanguage = "de",
+            allInstalledLanguages = true,
+            alwaysIncluded = listOf("en")
+        )
+
+        assertEquals("de", languages.first())
+        assertEquals(emptySet(), preferredLanguageTags().toSet() - languages.toSet())
+        assertEquals(languages, languages.distinct())
+    }
+
+    @Test fun stringArrayCarriesEveryTranslation() {
+        val minutes = localizedStringArray(MINUTES)
+        assertTrue("minutes" in minutes.getValue("en"))
+        assertTrue("minuten" in minutes.getValue("de"))
+    }
+
+    @Test fun unknownResourcesResolveToNothing() {
+        assertEquals(emptyMap(), localizedString("nope"))
+        assertEquals(emptyMap(), localizedStringArray("nope"))
+        assertEquals(
+            emptyList(),
+            multiLocalize(listOf("nope"), activeLanguage = "de", allInstalledLanguages = false)
+        )
+    }
+
+    @Test fun resourcesAreCollectedPerLanguageInRelevanceOrder() {
+        val localized = multiLocalize(
+            names = listOf(MINUTES, TO),
+            activeLanguage = "de",
+            allInstalledLanguages = false,
+            alwaysIncluded = listOf("en")
+        )
+
+        assertEquals(2, localized.size)
+        assertTrue("minuten" in localized.first().getValue(MINUTES))
+        assertTrue("bis" in localized.first().getValue(TO))
+        assertTrue("minutes" in localized.last().getValue(MINUTES))
+    }
+
+    @Test fun languagesWithoutAnyOfTheResourcesAreSkipped() = assertEquals(
+        emptyList(),
+        multiLocalize(listOf(MINUTES), activeLanguage = "ta", allInstalledLanguages = false)
+    )
+}

--- a/shared/src/commonTest/kotlin/de/kitshn/time/TimerDetectionTest.kt
+++ b/shared/src/commonTest/kotlin/de/kitshn/time/TimerDetectionTest.kt
@@ -27,8 +27,8 @@ class TimerDetectionTest {
         )
     )
 
-    private fun String.timerUris(): List<String> =
-        Regex("""\(timer[^)]+\)""").findAll(detectTimers(this, defs)).map { it.value }.toList()
+    private fun String.timerUris(withDefs: TimerDetectionDefs = defs): List<String> =
+        Regex("""\(timer[^)]+\)""").findAll(detectTimers(this, withDefs)).map { it.value }.toList()
 
     private fun String.singleUri() = timerUris().also {
         assertEquals(1, it.size, "Expected exactly one timer in: \"$this\", got: $it")
@@ -66,7 +66,7 @@ class TimerDetectionTest {
 
     @Test fun germanDiminutiveSekuendchen() = assertEquals("(timer://30)", "30 Sekündchen".singleUri())
 
-    @Test fun decimalSeconds() = assertEquals("(timer://2)", "2.5 s".singleUri())
+    @Test fun decimalSeconds() = assertEquals("(timer://3)", "2.5 s".singleUri())
 
     // -- Combos
 
@@ -90,9 +90,11 @@ class TimerDetectionTest {
 
     @Test fun wordRangeTo() = assertEquals("(timer-range://600/900)", "10 to 15 min".singleUri())
 
-    @Test fun dashRangeSeconds() = assertEquals("(timer-range://15/23)", "15-23.5 sec".singleUri())
+    @Test fun dashRangeSeconds() = assertEquals("(timer-range://15/24)", "15-23.5 sec".singleUri())
 
     @Test fun dashRangeHours() = assertEquals("(timer-range://3600/7200)", "1-2 Stunden".singleUri())
+
+    @Test fun dashSpecialMinutes() = assertEquals("(timer-range://600/900)", "10–15 Min.".singleUri())
 
     @Test fun decimalCommaRangeMinutes() = assertEquals("(timer-range://90/150)", "1,5-2,5 min".singleUri())
 
@@ -148,4 +150,124 @@ class TimerDetectionTest {
     @Test fun noMatchNumberAlone() = assertTrue("Nimm 5 Äpfel".timerUris().isEmpty())
 
     @Test fun noMatchNumberAloneMisleadingSeconds() = assertTrue("Die 2 Sekundarstufe :D".timerUris().isEmpty())
+
+    // -- dash variants
+
+    @Test fun emDashRangeMinutes() = assertEquals("(timer-range://600/900)", "10\u201415 min".singleUri())
+
+    @Test fun figureDashRangeMinutes() = assertEquals("(timer-range://600/900)", "10\u201215 min".singleUri())
+
+    @Test fun horizontalBarRangeMinutes() = assertEquals("(timer-range://600/900)", "10\u201515 min".singleUri())
+
+    @Test fun nonBreakingHyphenRangeMinutes() = assertEquals("(timer-range://600/900)", "10\u201115 min".singleUri())
+
+    @Test fun minusSignRangeMinutes() = assertEquals("(timer-range://600/900)", "10\u221215 min".singleUri())
+
+    @Test fun fullwidthHyphenRangeMinutes() = assertEquals("(timer-range://600/900)", "10\uFF0D15 min".singleUri())
+
+    @Test fun waveDashRangeMinutes() = assertEquals("(timer-range://600/900)", "10\u301C15 min".singleUri())
+
+    @Test fun spacedEmDashRangeHours() = assertEquals("(timer-range://3600/7200)", "1 \u2014 2 Stunden".singleUri())
+
+    // -- non-latin vocabularies
+
+    private val cyrillicDefs = TimerDetectionDefs(
+        hourDefs = setOf("\u0447\u0430\u0441\u043E\u0432", "\u0447\u0430\u0441\u0430", "\u0447"),
+        andDefs = setOf("\u0438"),
+        minuteDefs = setOf("\u043C\u0438\u043D\u0443\u0442", "\u043C\u0438\u043D"),
+        secondDefs = setOf("\u0441\u0435\u043A\u0443\u043D\u0434", "\u0441\u0435\u043A"),
+        rangeDefs = setOf("\u0434\u043E")
+    )
+
+    private fun String.cyrillicUris(): List<String> =
+        Regex("""\(timer[^)]+\)""").findAll(detectTimers(this, cyrillicDefs)).map { it.value }.toList()
+
+    @Test fun cyrillicMinutes() =
+        assertEquals(listOf("(timer://900)"), "\u0432\u0430\u0440\u0438\u0442\u044C 15 \u043C\u0438\u043D\u0443\u0442".cyrillicUris())
+
+    @Test fun cyrillicDashRange() =
+        assertEquals(listOf("(timer-range://600/900)"), "10\u201315 \u043C\u0438\u043D".cyrillicUris())
+
+    /** "\u043C\u0438\u043D" is a prefix of "\u043C\u0438\u043D\u0434\u0430\u043B\u044C" (almond); the ASCII-only (?!\w) guard cannot catch that. */
+    @Test fun cyrillicNoMatchInsideLongerWord() =
+        assertTrue("\u0434\u043E\u0431\u0430\u0432\u044C 5 \u043C\u0438\u043D\u0434\u0430\u043B\u044C".cyrillicUris().isEmpty())
+
+    // -- FRACTIONS
+
+    @Test fun mixedAsciiFractionHours() = assertEquals("(timer://9000)", "2 1/2 hours".singleUri())
+
+    @Test fun mixedVulgarFractionHours() = assertEquals("(timer://9000)", "2 \u00BD hours".singleUri())
+
+    @Test fun gluedVulgarFractionHours() = assertEquals("(timer://9000)", "2\u00BD Stunden".singleUri())
+
+    @Test fun asciiFractionOnly() = assertEquals("(timer://1800)", "1/2 hour".singleUri())
+
+    @Test fun vulgarFractionOnly() = assertEquals("(timer://1800)", "\u00BD Stunde".singleUri())
+
+    @Test fun vulgarFractionQuarterHour() = assertEquals("(timer://900)", "\u00BC h".singleUri())
+
+    @Test fun thirdOfAnHourRoundsCleanly() = assertEquals("(timer://1200)", "\u2153 Stunde".singleUri())
+
+    @Test fun fractionRange() =
+        assertEquals("(timer-range://5400/7200)", "1 1/2 bis 2 Stunden".singleUri())
+
+    @Test fun fractionKeepsWholeFigureInLinkText() = assertEquals(
+        "[**\u23F2 2 1/2 hours**](timer://9000)",
+        detectTimers("2 1/2 hours", defs)
+    )
+
+    /** A fraction without a unit is an amount, not a timer. */
+    @Test fun fractionWithoutUnitIsNoTimer() =
+        assertTrue("add 1/2 cup sugar and 2 \u00BD cups flour".timerUris().isEmpty())
+
+    // -- vocabulary resolution
+
+    @Test fun defsAlwaysIncludeEnglishAndUnitSymbols() {
+        val defs = timerDetectionDefs(activeLanguage = "fr", allInstalledLanguages = false)
+        assertTrue("minutes" in defs.minuteDefs)
+        assertTrue("min" in defs.minuteDefs)
+        assertTrue("h" in defs.hourDefs)
+    }
+
+    @Test fun defsMergeActiveLanguageWithEnglish() {
+        val defs = timerDetectionDefs(activeLanguage = "de", allInstalledLanguages = false)
+        assertTrue("minuten" in defs.minuteDefs)
+        assertTrue("minutes" in defs.minuteDefs)
+        assertTrue("bis" in defs.rangeDefs)
+        assertTrue("to" in defs.rangeDefs)
+    }
+
+    @Test fun mergedDefsDetectBothLanguages() {
+        val defs = timerDetectionDefs(activeLanguage = "de", allInstalledLanguages = false)
+        assertEquals("[**\u23F2 10 bis 15 Minuten**](timer-range://600/900)", detectTimers("10 bis 15 Minuten", defs))
+        assertEquals("[**\u23F2 10 to 15 minutes**](timer-range://600/900)", detectTimers("10 to 15 minutes", defs))
+    }
+
+    @Test fun alternativeRangeWordsAreDetected() {
+        val defs = timerDetectionDefs(activeLanguage = "de", allInstalledLanguages = false)
+        assertEquals("[**\u23F2 3 or 4 minutes**](timer-range://180/240)", detectTimers("3 or 4 minutes", defs))
+        assertEquals("[**\u23F2 10 until 15 minutes**](timer-range://600/900)", detectTimers("10 until 15 minutes", defs))
+        assertEquals("[**\u23F2 10 till 15 min**](timer-range://600/900)", detectTimers("10 till 15 min", defs))
+        assertEquals("[**\u23F2 10 oder 15 Minuten**](timer-range://600/900)", detectTimers("10 oder 15 Minuten", defs))
+    }
+
+    @Test fun ampersandJoinsHoursAndMinutes() {
+        val defs = timerDetectionDefs(activeLanguage = "de", allInstalledLanguages = false)
+        assertEquals("[**\u23F2 1 hour & 30 minutes**](timer://5400)", detectTimers("1 hour & 30 minutes", defs))
+        assertEquals("[**\u23F2 1 Stunde & 30 Minuten**](timer://5400)", detectTimers("1 Stunde & 30 Minuten", defs))
+    }
+
+    @Test fun germanRangeQualifiersAreDetected() {
+        val defs = timerDetectionDefs(activeLanguage = "de", allInstalledLanguages = false)
+        assertEquals("[**\u23F2 10 bis max. 15 Minuten**](timer-range://600/900)", detectTimers("10 bis max. 15 Minuten", defs))
+        assertEquals("[**\u23F2 10 bis knapp 15 Minuten**](timer-range://600/900)", detectTimers("10 bis knapp 15 Minuten", defs))
+    }
+
+    /** A merged vocabulary must not turn ordinary words into timers. */
+    @Test fun mergedDefsDoNotMisreadOrdinaryWords() {
+        val defs = timerDetectionDefs(activeLanguage = "de", allInstalledLanguages = false)
+        assertTrue("Nimm 5 \u00C4pfel".timerUris(defs).isEmpty())
+        assertTrue("Die 2 Sekundarstufe :D".timerUris(defs).isEmpty())
+        assertTrue("add 3 minced garlic cloves".timerUris(defs).isEmpty())
+    }
 }

--- a/shared/src/commonTest/kotlin/de/kitshn/time/TimerDetectionTest.kt
+++ b/shared/src/commonTest/kotlin/de/kitshn/time/TimerDetectionTest.kt
@@ -220,6 +220,61 @@ class TimerDetectionTest {
     @Test fun fractionWithoutUnitIsNoTimer() =
         assertTrue("add 1/2 cup sugar and 2 \u00BD cups flour".timerUris().isEmpty())
 
+    // -- SPELLED OUT NUMBERS
+
+    private val spelled = timerDetectionDefs(activeLanguage = "de", allInstalledLanguages = false)
+
+    @Test fun spelledOutMinutes() =
+        assertEquals("(timer://300)", "f\u00FCnf Minuten k\u00F6cheln".timerUris(spelled).single())
+
+    @Test fun spelledOutIsCaseInsensitive() =
+        assertEquals("(timer://300)", "F\u00FCnf Minuten".timerUris(spelled).single())
+
+    @Test fun spelledOutHour() =
+        assertEquals("(timer://3600)", "eine Stunde ruhen".timerUris(spelled).single())
+
+    @Test fun spelledOutHalfHour() = assertEquals(
+        "[**\u23F2 eine halbe Stunde**](timer://1800) ruhen",
+        detectTimers("eine halbe Stunde ruhen", spelled)
+    )
+
+    @Test fun spelledOutQuarterHour() =
+        assertEquals("(timer://900)", "eine viertel Stunde".timerUris(spelled).single())
+
+    @Test fun spelledOutOneAndAHalf() =
+        assertEquals("(timer://5400)", "anderthalb Stunden backen".timerUris(spelled).single())
+
+    @Test fun spelledOutRange() =
+        assertEquals("(timer-range://1200/1800)", "zwanzig bis drei\u00DFig Minuten".timerUris(spelled).single())
+
+    @Test fun spelledOutMixesWithDigits() =
+        assertEquals("(timer-range://300/600)", "f\u00FCnf bis 10 Minuten".timerUris(spelled).single())
+
+    @Test fun spelledOutHoursAndMinutes() =
+        assertEquals("(timer://5400)", "eine Stunde und drei\u00DFig Minuten".timerUris(spelled).single())
+
+    @Test fun spelledOutEnglish() {
+        assertEquals("(timer://300)", "five minutes".timerUris(spelled).single())
+        assertEquals("(timer://2700)", "forty-five minutes".timerUris(spelled).single())
+        assertEquals("(timer://5400)", "one and a half hours".timerUris(spelled).single())
+        assertEquals("(timer-range://600/900)", "ten to fifteen minutes".timerUris(spelled).single())
+    }
+
+    @Test fun spelledOutMultiWordEnglish() = assertEquals(
+        "[**\u23F2 half an hour**](timer://1800)",
+        detectTimers("half an hour", spelled)
+    )
+
+    /** A spelled out number without a unit is an amount, not a timer. */
+    @Test fun spelledOutWithoutUnitIsNoTimer() {
+        assertTrue("Nimm f\u00FCnf \u00C4pfel".timerUris(spelled).isEmpty())
+        assertTrue("add five garlic cloves".timerUris(spelled).isEmpty())
+    }
+
+    /** A longer word starting with a number word must not be read as that number. */
+    @Test fun spelledOutDoesNotMatchInsideLongerWords() =
+        assertTrue("f\u00FCnfzig Minuten".timerUris(spelled).none { it == "(timer://300)" })
+
     // -- vocabulary resolution
 
     @Test fun defsAlwaysIncludeEnglishAndUnitSymbols() {

--- a/shared/src/iosMain/kotlin/de/kitshn/language/MultiLocalize.ios.kt
+++ b/shared/src/iosMain/kotlin/de/kitshn/language/MultiLocalize.ios.kt
@@ -1,0 +1,7 @@
+package de.kitshn.language
+
+import platform.Foundation.NSLocale
+import platform.Foundation.preferredLanguages
+
+actual fun preferredLanguageTags(): List<String> =
+    NSLocale.preferredLanguages.filterIsInstance<String>().normalizeLanguageTags()

--- a/shared/src/jvmMain/kotlin/de/kitshn/language/MultiLocalize.jvm.kt
+++ b/shared/src/jvmMain/kotlin/de/kitshn/language/MultiLocalize.jvm.kt
@@ -1,0 +1,18 @@
+package de.kitshn.language
+
+import java.util.Locale
+
+actual fun preferredLanguageTags(): List<String> {
+    // using posix LANG env is the best we can do
+    val fromEnvironment = listOf("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG")
+        .mapNotNull(System::getenv)
+        .flatMap { it.split(':') }
+        .map { it.substringBefore('.') }
+
+    val fromJvm = listOf(
+        Locale.getDefault(Locale.Category.DISPLAY).language,
+        Locale.getDefault(Locale.Category.FORMAT).language
+    )
+
+    return (fromEnvironment + fromJvm).normalizeLanguageTags()
+}


### PR DESCRIPTION
This adds some more features to the timer detector

1. I noticed some of the imported recipes use weird unicode dash symbols so i added much more dash like en-, em-, ~- and everything as options
2. Fractions are now supported such lik 2 1/2 hours
3. I wanted to try to solve https://github.com/aimok04/kitshn/issues/425 
I had two ideas, the currently implemented one is to do the parsing in all languages (We just merge the Keywords of all languages) since we cannot query local resources of other languages I added a small gradle tasks that creates maps of the wanted resources at build time. 

A second idea would be to detect the language which would be easily possible using google mlkit, Apple NLLanguageDetector or https://github.com/pemistahl/lingua hover the first 2 would be a violation against FOSS rules of FDroid and the last isn't updated in 2 years idk. 

I also think this should much more be a feature of Tandoor and https://github.com/TandoorRecipes/recipes/issues/2254 vabene seems to agree but we can only wait there.

However just doing all installed languages is doing fine with most use cases i think. But i added a behavior setting just to make it optional (maybe it is unnecessary and should always be on?)

4. also added spelled out number support e.g. fünf Minuten kochen